### PR TITLE
feat: Initial scaffolding for Rust rewrite of CoovaChilli

### DIFF
--- a/coovachilli-rust/Cargo.toml
+++ b/coovachilli-rust/Cargo.toml
@@ -1,0 +1,7 @@
+[workspace]
+members = [
+    "chilli-core",
+    "chilli-net",
+    "chilli-http",
+    "chilli-bin",
+]

--- a/coovachilli-rust/README.md
+++ b/coovachilli-rust/README.md
@@ -1,0 +1,32 @@
+# CoovaChilli-Rust
+
+This is a rewrite of the CoovaChilli captive portal in Rust. The goal is to create a more modern, secure, and maintainable implementation of the original C-based project.
+
+## Project Structure
+
+The project is organized as a Rust workspace with the following crates:
+
+- `chilli-core`: Contains the core logic, data structures, and configuration management for the application.
+- `chilli-net`: Provides the networking components, including the TUN/TAP interface, DHCP server, and RADIUS client.
+- `chilli-http`: Implements the UAM/captive portal HTTP server using the `axum` framework.
+- `chilli-bin`: The main binary crate that integrates all the other components and runs the application.
+
+## Building and Running
+
+**Note:** This project is still in the early stages of development and is not yet functional.
+
+To build the project, you will need to have Rust and Cargo installed. You can then build the project by running the following command from the root of the workspace:
+
+```
+cargo build
+```
+
+To run the application, you will need to create a `chilli.toml` configuration file. An example configuration file can be found in `chilli-core/tests/chilli.toml`. You can then run the application with the following command:
+
+```
+cargo run -p chilli-bin -- --config-file /path/to/your/chilli.toml
+```
+
+## Contributing
+
+Contributions are welcome! Please feel free to open an issue or submit a pull request.

--- a/coovachilli-rust/chilli-bin/Cargo.toml
+++ b/coovachilli-rust/chilli-bin/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "chilli-bin"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+chilli-core = { path = "../chilli-core" }
+chilli-net = { path = "../chilli-net" }
+chilli-http = { path = "../chilli-http" }
+clap = { version = "4.0", features = ["derive"] }
+tokio = { version = "1", features = ["full"] }
+tracing = "0.1"
+toml = "0.8"

--- a/coovachilli-rust/chilli-bin/src/config.rs
+++ b/coovachilli-rust/chilli-bin/src/config.rs
@@ -1,0 +1,25 @@
+use clap::Parser;
+use chilli_core::Config;
+use std::fs;
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+pub struct Args {
+    #[clap(short, long, value_parser, default_value = "/etc/chilli/chilli.toml")]
+    pub config_file: PathBuf,
+}
+
+pub fn load_config() -> Result<Config, Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    let config_contents = fs::read_to_string(args.config_file)?;
+
+    // This is a placeholder. In a real implementation, you would use a library
+    // like `toml` to parse the config file and then merge it with command-line
+    // arguments. For now, we'll just return a default config.
+
+    let config: Config = toml::from_str(&config_contents)?;
+
+    Ok(config)
+}

--- a/coovachilli-rust/chilli-bin/src/main.rs
+++ b/coovachilli-rust/chilli-bin/src/main.rs
@@ -1,0 +1,63 @@
+mod config;
+
+use anyhow::Result;
+use chilli_core::Config;
+use chilli_http::server;
+use chilli_net::dhcp::DhcpServer;
+use chilli_net::radius::RadiusClient;
+use chilli_net::tun;
+use tokio::io::AsyncReadExt;
+use tracing::{error, info};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    info!("Starting CoovaChilli-Rust");
+
+    let config = match config::load_config() {
+        Ok(config) => config,
+        Err(e) => {
+            eprintln!("Error loading config: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    info!("Config loaded: {:?}", config);
+
+    let mut iface = match tun::create_tun(&config) {
+        Ok(iface) => iface,
+        Err(e) => {
+            error!("Error creating TUN interface: {}", e);
+            std::process::exit(1);
+        }
+    };
+
+    let config_clone_http = config.clone();
+    let http_server_handle = tokio::spawn(async move {
+        if let Err(e) = server::run_server(&config_clone_http).await {
+            error!("HTTP server error: {}", e);
+        }
+    });
+
+    let dhcp_server = DhcpServer::new(config.clone()).await?;
+    let dhcp_server_handle = tokio::spawn(async move {
+        if let Err(e) = dhcp_server.run().await {
+            error!("DHCP server error: {}", e);
+        }
+    });
+
+    let radius_client = RadiusClient::new(config.clone()).await?;
+    let radius_client_handle = tokio::spawn(async move {
+        if let Err(e) = radius_client.run().await {
+            error!("RADIUS client error: {}", e);
+        }
+    });
+
+    let mut buf = [0u8; 1504];
+    loop {
+        let n = iface.read(&mut buf).await?;
+        info!("Read {} bytes from TUN interface", n);
+        // Here we would process the packet
+    }
+}

--- a/coovachilli-rust/chilli-core/Cargo.toml
+++ b/coovachilli-rust/chilli-core/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "chilli-core"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+tokio = { version = "1", features = ["full"] }
+tracing = "0.1"
+
+[dev-dependencies]
+toml = "0.8"

--- a/coovachilli-rust/chilli-core/src/config.rs
+++ b/coovachilli-rust/chilli-core/src/config.rs
@@ -1,0 +1,74 @@
+use serde::Deserialize;
+use std::net::Ipv4Addr;
+
+/// The main configuration for the CoovaChilli application.
+///
+/// This struct holds all the configuration options for the application,
+/// which are loaded from a TOML file and command-line arguments.
+#[derive(Deserialize, Debug, Clone)]
+pub struct Config {
+    /// Run the application in the foreground.
+    pub foreground: bool,
+    /// Enable debug logging.
+    pub debug: bool,
+    /// The syslog facility to use for logging.
+    pub logfacility: i32,
+    /// The log level to use.
+    pub loglevel: i32,
+    /// The interval at which to re-read the configuration file.
+    pub interval: i32,
+    /// The path to the PID file.
+    pub pidfile: String,
+    /// The path to the state directory.
+    pub statedir: String,
+
+    /// The network address of the TUN/TAP interface.
+    pub net: Ipv4Addr,
+    /// The netmask of the TUN/TAP interface.
+    pub mask: Ipv4Addr,
+    /// The name of the TUN/TAP device.
+    pub tundev: Option<String>,
+    /// The dynamic IP address pool.
+    pub dynip: Option<String>,
+    /// The static IP address pool.
+    pub statip: Option<String>,
+
+    /// The primary DNS server IP address.
+    pub dns1: Ipv4Addr,
+    /// The secondary DNS server IP address.
+    pub dns2: Ipv4Addr,
+    /// The domain to use for DNS lookups.
+    pub domain: Option<String>,
+
+    /// The IP address to listen on for RADIUS requests.
+    pub radiuslisten: Ipv4Addr,
+    /// The IP address of the primary RADIUS server.
+    pub radiusserver1: Ipv4Addr,
+    /// The IP address of the secondary RADIUS server.
+    pub radiusserver2: Ipv4Addr,
+    /// The shared secret for the RADIUS server.
+    pub radiussecret: String,
+    /// The UDP port for RADIUS authentication.
+    pub radiusauthport: u16,
+    /// The UDP port for RADIUS accounting.
+    pub radiusacctport: u16,
+
+    /// The network interface to use for DHCP.
+    pub dhcpif: String,
+    /// The IP address to listen on for DHCP requests.
+    pub dhcplisten: Ipv4Addr,
+    /// The DHCP lease time in seconds.
+    pub lease: i32,
+
+    /// The shared secret for the UAM server.
+    pub uamsecret: Option<String>,
+    /// The URL of the UAM server.
+    pub uamurl: Option<String>,
+    /// The IP address to listen on for UAM requests.
+    pub uamlisten: Ipv4Addr,
+    /// The TCP port to listen on for UAM requests.
+    pub uamport: u16,
+
+    /// The maximum number of clients to allow.
+    pub max_clients: i32,
+}

--- a/coovachilli-rust/chilli-core/src/lib.rs
+++ b/coovachilli-rust/chilli-core/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod config;
+pub mod session;
+
+pub use config::Config;
+pub use session::{Connection, SessionParams, SessionState};

--- a/coovachilli-rust/chilli-core/src/session.rs
+++ b/coovachilli-rust/chilli-core/src/session.rs
@@ -1,0 +1,71 @@
+use std::net::Ipv4Addr;
+
+pub struct SessionParams {
+    pub url: Option<String>,
+    pub filterid: Option<String>,
+    pub routeidx: u8,
+    pub bandwidthmaxup: u64,
+    pub bandwidthmaxdown: u64,
+    pub maxinputoctets: u64,
+    pub maxoutputoctets: u64,
+    pub maxtotaloctets: u64,
+    pub sessiontimeout: u64,
+    pub idletimeout: u32,
+    pub interim_interval: u16,
+    pub sessionterminatetime: u64,
+    pub flags: u16,
+}
+
+pub struct RedirState {
+    pub username: Option<String>,
+    pub userurl: Option<String>,
+    pub uamchal: [u8; 16],
+    pub class: Option<Vec<u8>>,
+    pub cui: Option<Vec<u8>>,
+    pub state: Option<Vec<u8>>,
+    pub eap_identity: u8,
+    pub uamprotocol: u8,
+}
+
+pub struct SessionState {
+    pub redir: RedirState,
+    pub authenticated: bool,
+    pub sessionid: String,
+    pub start_time: u64,
+    pub interim_time: u64,
+    pub last_bw_time: u64,
+    pub last_up_time: u64,
+    pub last_time: u64,
+    pub uamtime: u64,
+    pub input_packets: u64,
+    pub output_packets: u64,
+    pub input_octets: u64,
+    pub output_octets: u64,
+    pub terminate_cause: u32,
+    pub session_id: u32,
+}
+
+pub struct Connection {
+    pub next: Option<Box<Connection>>,
+    pub prev: Option<Box<Connection>>,
+    pub uplink: (), // Placeholder
+    pub dnlink: (), // Placeholder
+    pub inuse: bool,
+    pub is_adminsession: bool,
+    pub uamabort: bool,
+    pub uamexit: bool,
+    pub unit: i32,
+    pub dnprot: i32,
+    pub rt: i64,
+    pub params: SessionParams,
+    pub state: SessionState,
+    pub hismac: [u8; 6],
+    pub ourip: Ipv4Addr,
+    pub hisip: Ipv4Addr,
+    pub hismask: Ipv4Addr,
+    pub reqip: Ipv4Addr,
+    pub net: Ipv4Addr,
+    pub mask: Ipv4Addr,
+    pub dns1: Ipv4Addr,
+    pub dns2: Ipv4Addr,
+}

--- a/coovachilli-rust/chilli-core/tests/chilli.toml
+++ b/coovachilli-rust/chilli-core/tests/chilli.toml
@@ -1,0 +1,35 @@
+foreground = true
+debug = true
+logfacility = 1
+loglevel = 7
+interval = 3600
+pidfile = "/var/run/chilli.pid"
+statedir = "/var/lib/chilli"
+
+net = "192.168.182.0"
+mask = "255.255.255.0"
+tundev = "tun0"
+dynip = "192.168.182.0/24"
+statip = "10.1.0.0/16"
+
+dns1 = "8.8.8.8"
+dns2 = "8.8.4.4"
+domain = "coova.org"
+
+radiuslisten = "127.0.0.1"
+radiusserver1 = "127.0.0.1"
+radiusserver2 = "127.0.0.1"
+radiussecret = "testing123"
+radiusauthport = 1812
+radiusacctport = 1813
+
+dhcpif = "eth1"
+dhcplisten = "192.168.182.1"
+lease = 86400
+
+uamsecret = "uamsecret"
+uamurl = "http://127.0.0.1/uam"
+uamlisten = "192.168.182.1"
+uamport = 3990
+
+max_clients = 256

--- a/coovachilli-rust/chilli-core/tests/config_test.rs
+++ b/coovachilli-rust/chilli-core/tests/config_test.rs
@@ -1,0 +1,45 @@
+use chilli_core::Config;
+use std::fs;
+use std::net::Ipv4Addr;
+
+#[test]
+fn test_load_config() {
+    let config_contents = fs::read_to_string("tests/chilli.toml").unwrap();
+    let config: Config = toml::from_str(&config_contents).unwrap();
+
+    assert_eq!(config.foreground, true);
+    assert_eq!(config.debug, true);
+    assert_eq!(config.logfacility, 1);
+    assert_eq!(config.loglevel, 7);
+    assert_eq!(config.interval, 3600);
+    assert_eq!(config.pidfile, "/var/run/chilli.pid");
+    assert_eq!(config.statedir, "/var/lib/chilli");
+
+    assert_eq!(config.net, Ipv4Addr::new(192, 168, 182, 0));
+    assert_eq!(config.mask, Ipv4Addr::new(255, 255, 255, 0));
+    assert_eq!(config.tundev, Some("tun0".to_string()));
+    assert_eq!(config.dynip, Some("192.168.182.0/24".to_string()));
+    assert_eq!(config.statip, Some("10.1.0.0/16".to_string()));
+
+    assert_eq!(config.dns1, Ipv4Addr::new(8, 8, 8, 8));
+    assert_eq!(config.dns2, Ipv4Addr::new(8, 8, 4, 4));
+    assert_eq!(config.domain, Some("coova.org".to_string()));
+
+    assert_eq!(config.radiuslisten, Ipv4Addr::new(127, 0, 0, 1));
+    assert_eq!(config.radiusserver1, Ipv4Addr::new(127, 0, 0, 1));
+    assert_eq!(config.radiusserver2, Ipv4Addr::new(127, 0, 0, 1));
+    assert_eq!(config.radiussecret, "testing123");
+    assert_eq!(config.radiusauthport, 1812);
+    assert_eq!(config.radiusacctport, 1813);
+
+    assert_eq!(config.dhcpif, "eth1");
+    assert_eq!(config.dhcplisten, Ipv4Addr::new(192, 168, 182, 1));
+    assert_eq!(config.lease, 86400);
+
+    assert_eq!(config.uamsecret, Some("uamsecret".to_string()));
+    assert_eq!(config.uamurl, Some("http://127.0.0.1/uam".to_string()));
+    assert_eq!(config.uamlisten, Ipv4Addr::new(192, 168, 182, 1));
+    assert_eq!(config.uamport, 3990);
+
+    assert_eq!(config.max_clients, 256);
+}

--- a/coovachilli-rust/chilli-http/Cargo.toml
+++ b/coovachilli-rust/chilli-http/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "chilli-http"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+chilli-core = { path = "../chilli-core" }
+axum = "0.7"
+tokio = { version = "1", features = ["full"] }
+tracing = "0.1"

--- a/coovachilli-rust/chilli-http/src/lib.rs
+++ b/coovachilli-rust/chilli-http/src/lib.rs
@@ -1,0 +1,1 @@
+pub mod server;

--- a/coovachilli-rust/chilli-http/src/server.rs
+++ b/coovachilli-rust/chilli-http/src/server.rs
@@ -1,0 +1,20 @@
+use axum::{routing::get, Router};
+use chilli_core::Config;
+use std::net::SocketAddr;
+use tracing::info;
+
+async fn root() -> &'static str {
+    "Hello, World!"
+}
+
+pub async fn run_server(config: &Config) -> Result<(), Box<dyn std::error::Error>> {
+    let app = Router::new().route("/", get(root));
+
+    let addr = SocketAddr::new(config.uamlisten.into(), config.uamport);
+    info!("UAM server listening on {}", addr);
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}

--- a/coovachilli-rust/chilli-net/Cargo.toml
+++ b/coovachilli-rust/chilli-net/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "chilli-net"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+chilli-core = { path = "../chilli-core" }
+tun-tap = "0.1.4"
+tokio = { version = "1", features = ["full"] }
+tracing = "0.1"
+byteorder = "1.4"
+anyhow = "1.0"
+getrandom = "0.2"

--- a/coovachilli-rust/chilli-net/src/dhcp.rs
+++ b/coovachilli-rust/chilli-net/src/dhcp.rs
@@ -1,0 +1,159 @@
+use anyhow::Result;
+use chilli_core::Config;
+use std::net::Ipv4Addr;
+use tokio::net::UdpSocket;
+use tracing::{info, warn};
+
+/// DHCP Message Types (RFC 2132)
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u8)]
+pub enum DhcpMessageType {
+    Discover = 1,
+    Offer = 2,
+    Request = 3,
+    Decline = 4,
+    Ack = 5,
+    Nak = 6,
+    Release = 7,
+    Inform = 8,
+    ForceRenew = 9,
+}
+
+/// BOOTP Message Types
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u8)]
+pub enum BootpMessageType {
+    BootRequest = 1,
+    BootReply = 2,
+}
+
+// DHCP Options
+pub const DHCP_OPTION_PAD: u8 = 0;
+pub const DHCP_OPTION_SUBNET_MASK: u8 = 1;
+pub const DHCP_OPTION_ROUTER_OPTION: u8 = 3;
+pub const DHCP_OPTION_DNS: u8 = 6;
+pub const DHCP_OPTION_HOSTNAME: u8 = 12;
+pub const DHCP_OPTION_DOMAIN_NAME: u8 = 15;
+pub const DHCP_OPTION_REQUESTED_IP: u8 = 50;
+pub const DHCP_OPTION_LEASE_TIME: u8 = 51;
+pub const DHCP_OPTION_MESSAGE_TYPE: u8 = 53;
+pub const DHCP_OPTION_SERVER_ID: u8 = 54;
+pub const DHCP_OPTION_PARAMETER_REQUEST_LIST: u8 = 55;
+pub const DHCP_OPTION_END: u8 = 255;
+
+pub const DHCP_MAGIC_COOKIE: [u8; 4] = [0x63, 0x82, 0x53, 0x63];
+
+/// Represents a DHCP packet.
+///
+/// This struct is a direct mapping of the DHCP packet structure as defined in
+/// RFC 2131. It uses `#[repr(C, packed)]` to ensure that the memory layout
+/// matches the network packet format.
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct DhcpPacket {
+    pub op: u8,
+    pub htype: u8,
+    pub hlen: u8,
+    pub hops: u8,
+    pub xid: u32,
+    pub secs: u16,
+    pub flags: u16,
+    pub ciaddr: u32,
+    pub yiaddr: u32,
+    pub siaddr: u32,
+    pub giaddr: u32,
+    pub chaddr: [u8; 16],
+    pub sname: [u8; 64],
+    pub file: [u8; 128],
+    pub options: [u8; 312],
+}
+
+impl DhcpPacket {
+    /// Creates a `DhcpPacket` from a byte slice.
+    ///
+    /// This function performs some basic validation to ensure that the byte slice
+    /// is a valid DHCP packet.
+    pub fn from_bytes(data: &[u8]) -> Option<&DhcpPacket> {
+        if data.len() < std::mem::size_of::<DhcpPacket>() {
+            return None;
+        }
+        // Safety: We've checked the length. The caller must ensure the
+        // data is correctly aligned. For network packets, this is usually fine.
+        let packet = unsafe { &*(data.as_ptr() as *const DhcpPacket) };
+
+        if packet.options[0..4] != DHCP_MAGIC_COOKIE {
+            return None;
+        }
+
+        Some(packet)
+    }
+
+    pub fn ciaddr(&self) -> Ipv4Addr {
+        Ipv4Addr::from(u32::from_be(self.ciaddr))
+    }
+
+    pub fn yiaddr(&self) -> Ipv4Addr {
+        Ipv4Addr::from(u32::from_be(self.yiaddr))
+    }
+
+    pub fn siaddr(&self) -> Ipv4Addr {
+        Ipv4Addr::from(u32::from_be(self.siaddr))
+    }
+
+    pub fn giaddr(&self) -> Ipv4Addr {
+        Ipv4Addr::from(u32::from_be(self.giaddr))
+    }
+
+    /// Returns a slice to the DHCP options.
+    pub fn options(&self) -> &[u8] {
+        &self.options[4..]
+    }
+}
+
+/// Represents a parsed DHCP option.
+pub struct DhcpOption<'a> {
+    pub code: u8,
+    pub len: u8,
+    pub data: &'a [u8],
+}
+
+/// The DHCP server.
+pub struct DhcpServer {
+    socket: UdpSocket,
+    config: Config,
+}
+
+impl DhcpServer {
+    /// Creates a new `DhcpServer`.
+    pub async fn new(config: Config) -> Result<Self> {
+        let addr = format!("{}:67", config.dhcplisten);
+        let socket = UdpSocket::bind(&addr).await?;
+        socket.set_broadcast(true)?;
+        info!("DHCP server listening on {}", addr);
+        Ok(DhcpServer { socket, config })
+    }
+
+    /// Runs the DHCP server.
+    ///
+    /// This function contains the main loop for the DHCP server. It listens for
+    /// incoming packets on the DHCP port and handles them accordingly.
+    pub async fn run(&self) -> Result<()> {
+        let mut buf = [0u8; 1500];
+        loop {
+            let (len, src) = self.socket.recv_from(&mut buf).await?;
+            info!("Received {} bytes from {}", len, src);
+
+            if let Some(packet) = DhcpPacket::from_bytes(&buf[..len]) {
+                self.handle_packet(packet, src).await?;
+            } else {
+                warn!("Received invalid DHCP packet from {}", src);
+            }
+        }
+    }
+
+    async fn handle_packet(&self, packet: &DhcpPacket, src: std::net::SocketAddr) -> Result<()> {
+        // Placeholder for packet handling logic
+        info!("Handling DHCP packet from {}", src);
+        Ok(())
+    }
+}

--- a/coovachilli-rust/chilli-net/src/firewall.rs
+++ b/coovachilli-rust/chilli-net/src/firewall.rs
@@ -1,0 +1,89 @@
+use chilli_core::Config;
+use std::process::Command;
+use tracing::{error, info};
+
+pub struct Firewall {
+    config: Config,
+}
+
+impl Firewall {
+    pub fn new(config: Config) -> Self {
+        Firewall { config }
+    }
+
+    pub fn initialize(&self) -> Result<(), std::io::Error> {
+        info!("Initializing firewall rules");
+
+        // Create ipset
+        self.run_command("ipset", &["create", "authenticated_users", "hash:ip"])?;
+
+        // Create chilli chains
+        self.run_command("iptables", &["-t", "mangle", "-N", "chilli"])?;
+        self.run_command("iptables", &["-t", "nat", "-N", "chilli"])?;
+        self.run_command("iptables", &["-t", "filter", "-N", "chilli"])?;
+
+        // Mangle table rules
+        self.run_command("iptables", &["-t", "mangle", "-A", "PREROUTING", "-j", "chilli"])?;
+        self.run_command("iptables", &["-t", "mangle", "-A", "chilli", "-m", "set", "--match-set", "authenticated_users", "src", "-j", "MARK", "--set-mark", "1"])?;
+
+        // NAT table rules
+        self.run_command("iptables", &["-t", "nat", "-A", "PREROUTING", "-j", "chilli"])?;
+        let dnat_dest = format!("{}:{}", self.config.uamlisten, self.config.uamport);
+        self.run_command("iptables", &["-t", "nat", "-A", "chilli", "-m", "mark", "!", "--mark", "1", "-p", "tcp", "--dport", "80", "-j", "DNAT", "--to-destination", &dnat_dest])?;
+
+        // Filter table rules
+        self.run_command("iptables", &["-t", "filter", "-A", "FORWARD", "-j", "chilli"])?;
+        self.run_command("iptables", &["-t", "filter", "-A", "chilli", "-m", "mark", "--mark", "1", "-j", "ACCEPT"])?;
+        self.run_command("iptables", &["-t", "filter", "-A", "chilli", "-p", "udp", "--dport", "53", "-j", "ACCEPT"])?;
+        let uam_dest = self.config.uamlisten.to_string();
+        let uam_port_str = self.config.uamport.to_string();
+        self.run_command("iptables", &["-t", "filter", "-A", "chilli", "-p", "tcp", "--dport", &uam_port_str, "-d", &uam_dest, "-j", "ACCEPT"])?;
+        self.run_command("iptables", &["-t", "filter", "-A", "chilli", "-j", "DROP"])?;
+
+        Ok(())
+    }
+
+    pub fn add_authenticated_ip(&self, ip: std::net::Ipv4Addr) -> Result<(), std::io::Error> {
+        info!("Adding {} to authenticated users", ip);
+        self.run_command("ipset", &["add", "authenticated_users", &ip.to_string()])
+    }
+
+    pub fn remove_authenticated_ip(&self, ip: std::net::Ipv4Addr) -> Result<(), std::io::Error> {
+        info!("Removing {} from authenticated users", ip);
+        self.run_command("ipset", &["del", "authenticated_users", &ip.to_string()])
+    }
+
+    pub fn cleanup(&self) -> Result<(), std::io::Error> {
+        info!("Cleaning up firewall rules");
+
+        // Mangle table rules
+        self.run_command("iptables", &["-t", "mangle", "-D", "PREROUTING", "-j", "chilli"])?;
+        self.run_command("iptables", &["-t", "mangle", "-F", "chilli"])?;
+        self.run_command("iptables", &["-t", "mangle", "-X", "chilli"])?;
+
+        // NAT table rules
+        self.run_command("iptables", &["-t", "nat", "-D", "PREROUTING", "-j", "chilli"])?;
+        self.run_command("iptables", &["-t", "nat", "-F", "chilli"])?;
+        self.run_command("iptables", &["-t", "nat", "-X", "chilli"])?;
+
+        // Filter table rules
+        self.run_command("iptables", &["-t", "filter", "-D", "FORWARD", "-j", "chilli"])?;
+        self.run_command("iptables", &["-t", "filter", "-F", "chilli"])?;
+        self.run_command("iptables", &["-t", "filter", "-X", "chilli"])?;
+
+        // Destroy ipset
+        self.run_command("ipset", &["destroy", "authenticated_users"])?;
+
+        Ok(())
+    }
+
+    fn run_command(&self, command: &str, args: &[&str]) -> Result<(), std::io::Error> {
+        let status = Command::new(command).args(args).status()?;
+        if !status.success() {
+            let msg = format!("Command '{}' with args '{:?}' failed with status {}", command, args, status);
+            error!("{}", msg);
+            return Err(std::io::Error::new(std::io::ErrorKind::Other, msg));
+        }
+        Ok(())
+    }
+}

--- a/coovachilli-rust/chilli-net/src/lib.rs
+++ b/coovachilli-rust/chilli-net/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod tun;
+pub mod dhcp;
+pub mod radius;
+pub mod firewall;

--- a/coovachilli-rust/chilli-net/src/radius.rs
+++ b/coovachilli-rust/chilli-net/src/radius.rs
@@ -1,0 +1,202 @@
+use anyhow::Result;
+use chilli_core::Config;
+use std::collections::HashMap;
+use std::net::Ipv4Addr;
+use std::sync::{Arc, Mutex};
+use tokio::net::UdpSocket;
+use tracing::{info, warn};
+
+// ... (existing enums and structs)
+
+// RADIUS Packet Codes
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[repr(u8)]
+pub enum RadiusCode {
+    AccessRequest = 1,
+    AccessAccept = 2,
+    AccessReject = 3,
+    AccountingRequest = 4,
+    AccountingResponse = 5,
+    AccessChallenge = 11,
+    StatusServer = 12,
+    StatusClient = 13,
+    DisconnectRequest = 40,
+    DisconnectAck = 41,
+    DisconnectNak = 42,
+    CoaRequest = 43,
+    CoaAck = 44,
+    CoaNak = 45,
+}
+
+// RADIUS Attributes
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[repr(u8)]
+pub enum RadiusAttributeType {
+    UserName = 1,
+    UserPassword = 2,
+    ChapPassword = 3,
+    NasIpAddress = 4,
+    NasPort = 5,
+    ServiceType = 6,
+    FramedProtocol = 7,
+    FramedIpAddress = 8,
+    FramedIpNetmask = 9,
+    FilterId = 11,
+    FramedMtu = 12,
+    State = 24,
+    Class = 25,
+    VendorSpecific = 26,
+    SessionTimeout = 27,
+    IdleTimeout = 28,
+    CalledStationId = 30,
+    CallingStationId = 31,
+    NasIdentifier = 32,
+    AcctStatusType = 40,
+    AcctDelayTime = 41,
+    AcctInputOctets = 42,
+    AcctOutputOctets = 43,
+    AcctSessionId = 44,
+    AcctAuthentic = 45,
+    AcctSessionTime = 46,
+    AcctInputPackets = 47,
+    AcctOutputPackets = 48,
+    AcctTerminateCause = 49,
+    AcctInputGigawords = 52,
+    AcctOutputGigawords = 53,
+    EventTimestamp = 55,
+    EapMessage = 79,
+    MessageAuthenticator = 80,
+    AcctInterimInterval = 85,
+    NasPortId = 87,
+}
+
+pub const RADIUS_HDR_LEN: usize = 20;
+pub const RADIUS_MAX_LEN: usize = 4096;
+pub const RADIUS_AUTH_LEN: usize = 16;
+
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct RadiusPacket {
+    pub code: u8,
+    pub id: u8,
+    pub length: u16,
+    pub authenticator: [u8; RADIUS_AUTH_LEN],
+    pub payload: [u8; RADIUS_MAX_LEN - RADIUS_HDR_LEN],
+}
+
+impl RadiusPacket {
+    pub fn from_bytes(data: &[u8]) -> Option<&RadiusPacket> {
+        if data.len() < RADIUS_HDR_LEN {
+            return None;
+        }
+        let len = u16::from_be_bytes([data[2], data[3]]) as usize;
+        if data.len() < len {
+            return None;
+        }
+        Some(unsafe { &*(data.as_ptr() as *const RadiusPacket) })
+    }
+
+    pub fn attributes(&self) -> &[u8] {
+        let len = u16::from_be(self.length) as usize;
+        &self.payload[..len - RADIUS_HDR_LEN]
+    }
+}
+
+#[repr(C, packed)]
+#[derive(Debug, Copy, Clone)]
+pub struct RadiusAttribute {
+    pub type_code: u8,
+    pub length: u8,
+    // The value is of variable length, so we can't define it here.
+    // We'll have a slice to the value instead.
+}
+
+pub struct RadiusAttributeValue<'a> {
+    pub type_code: RadiusAttributeType,
+    pub value: &'a [u8],
+}
+
+pub struct RadiusClient {
+    socket: UdpSocket,
+    config: Config,
+    next_id: Arc<Mutex<u8>>,
+}
+
+impl RadiusClient {
+    pub async fn new(config: Config) -> Result<Self> {
+        let addr = format!("{}:0", config.radiuslisten);
+        let socket = UdpSocket::bind(&addr).await?;
+        info!("RADIUS client listening on {}", socket.local_addr()?);
+        Ok(RadiusClient {
+            socket,
+            config,
+            next_id: Arc::new(Mutex::new(0)),
+        })
+    }
+
+    pub async fn run(&self) -> Result<()> {
+        let mut buf = [0u8; RADIUS_MAX_LEN];
+        loop {
+            let (len, src) = self.socket.recv_from(&mut buf).await?;
+            info!("Received {} bytes from {}", len, src);
+
+            if let Some(packet) = RadiusPacket::from_bytes(&buf[..len]) {
+                self.handle_packet(packet, src).await?;
+            } else {
+                warn!("Received invalid RADIUS packet from {}", src);
+            }
+        }
+    }
+
+    async fn handle_packet(&self, packet: &RadiusPacket, src: std::net::SocketAddr) -> Result<()> {
+        // Placeholder for packet handling logic
+        info!("Handling RADIUS packet from {}", src);
+        Ok(())
+    }
+
+    pub async fn send_access_request(&self, username: &str, password: &str) -> Result<()> {
+        let mut id = self.next_id.lock().unwrap();
+        let packet_id = *id;
+        *id = id.wrapping_add(1);
+
+        let mut authenticator = [0u8; RADIUS_AUTH_LEN];
+        // In a real implementation, this should be a random value.
+        getrandom::getrandom(&mut authenticator)?;
+
+        let mut attributes = Vec::new();
+        attributes.push(RadiusAttributeValue {
+            type_code: RadiusAttributeType::UserName,
+            value: username.as_bytes(),
+        });
+        // In a real implementation, the password would be encrypted.
+        attributes.push(RadiusAttributeValue {
+            type_code: RadiusAttributeType::UserPassword,
+            value: password.as_bytes(),
+        });
+
+        let mut payload = Vec::new();
+        for attr in attributes {
+            payload.push(attr.type_code as u8);
+            payload.push((attr.value.len() + 2) as u8);
+            payload.extend_from_slice(attr.value);
+        }
+
+        let length = (RADIUS_HDR_LEN + payload.len()) as u16;
+
+        let mut packet_bytes = Vec::with_capacity(length as usize);
+        packet_bytes.push(RadiusCode::AccessRequest as u8);
+        packet_bytes.push(packet_id);
+        packet_bytes.extend_from_slice(&length.to_be_bytes());
+        packet_bytes.extend_from_slice(&authenticator);
+        packet_bytes.extend_from_slice(&payload);
+
+        // In a real implementation, the Message-Authenticator would be calculated here.
+
+        let server_addr = format!("{}:{}", self.config.radiusserver1, self.config.radiusauthport);
+        self.socket.send_to(&packet_bytes, &server_addr).await?;
+
+        info!("Sent Access-Request for user '{}' to {}", username, server_addr);
+
+        Ok(())
+    }
+}

--- a/coovachilli-rust/chilli-net/src/tun.rs
+++ b/coovachilli-rust/chilli-net/src/tun.rs
@@ -1,0 +1,27 @@
+use chilli_core::Config;
+use tun_tap::{Iface, Mode};
+
+/// Creates and configures a new TUN interface.
+///
+/// # Arguments
+///
+/// * `config` - A reference to the application configuration.
+///
+/// # Returns
+///
+/// A `Result` containing the new `Iface` instance, or a `tun_tap::Error` if an
+/// error occurred.
+pub fn create_tun(config: &Config) -> Result<Iface, tun_tap::Error> {
+    let iface = Iface::new("", Mode::Tun)?;
+
+    if let Some(tundev) = &config.tundev {
+        iface.set_name(tundev)?;
+    }
+
+    iface.set_ip(config.net)?;
+    iface.set_netmask(config.mask)?;
+
+    iface.up()?;
+
+    Ok(iface)
+}


### PR DESCRIPTION
This commit introduces the initial scaffolding for a complete rewrite of the CoovaChilli captive portal in Rust.

The new implementation is organized as a Rust workspace with the following crates:
- `chilli-core`: Core logic, data structures, and configuration.
- `chilli-net`: Networking components (TUN/TAP, DHCP, RADIUS).
- `chilli-http`: UAM/captive portal HTTP server.
- `chilli-bin`: The main application binary.

Basic data structures for configuration, session management, DHCP packets, and RADIUS packets have been defined. The main application structure is in place, with `tokio` tasks for the different components.

A basic `README.md` and some initial documentation have been added.

NOTE: Due to a persistent environment issue, this code has not been compiled or tested. It is likely non-functional and contains errors. This submission is intended to provide a snapshot of the work done so far, as requested by the user.