### PR TITLE
feat(rust): Implement command socket for daemon management

### DIFF
--- a/coovachilli-rust/Cargo.lock
+++ b/coovachilli-rust/Cargo.lock
@@ -298,6 +298,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "chilli-ipc"
+version = "0.1.0"
+dependencies = [
+ "chilli-core",
+ "serde",
+]
+
+[[package]]
 name = "chilli-net"
 version = "0.1.0"
 dependencies = [
@@ -310,6 +318,17 @@ dependencies = [
  "tokio",
  "tracing",
  "tun-rs",
+]
+
+[[package]]
+name = "chilli-query"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chilli-ipc",
+ "clap",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/coovachilli-rust/Cargo.toml
+++ b/coovachilli-rust/Cargo.toml
@@ -3,5 +3,5 @@ members = [
     "chilli-core",
     "chilli-net",
     "chilli-http",
-    "chilli-bin",
+    "chilli-bin", "chilli-query", "chilli-ipc",
 ]

--- a/coovachilli-rust/chilli-bin/src/cmdsock.rs
+++ b/coovachilli-rust/chilli-bin/src/cmdsock.rs
@@ -1,0 +1,236 @@
+use anyhow::Result;
+use chilli_core::SessionManager;
+use chilli_ipc::{Command, Response};
+use chilli_net::{radius::RadiusClient, Firewall};
+use std::net::Ipv4Addr;
+use std::path::Path;
+use std::sync::Arc;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{UnixListener, UnixStream};
+use tracing::{error, info, warn};
+
+async fn handle_disconnect(
+    ip: Ipv4Addr,
+    session_manager: Arc<SessionManager>,
+    radius_client: Arc<RadiusClient>,
+    firewall: Arc<Firewall>,
+) -> Result<Response> {
+    info!("Received Disconnect command for IP {}", ip);
+
+    if let Some(session) = session_manager.get_session(&ip).await {
+        if session.state.authenticated {
+            // Send Acct-Stop
+            if let Err(e) = radius_client.send_acct_stop(&session).await {
+                warn!(
+                    "Failed to send Acct-Stop for session {}: {}",
+                    session.state.sessionid, e
+                );
+                // Continue with disconnection anyway
+            }
+
+            // Remove firewall rule
+            if let Err(e) = firewall.remove_authenticated_ip(ip) {
+                warn!("Failed to remove firewall rule for {}: {}", ip, e);
+                // Continue with disconnection anyway
+            }
+        }
+
+        // Remove session from manager
+        session_manager.remove_session(&ip).await;
+        info!("Session for {} disconnected and removed.", ip);
+        Ok(Response::Success)
+    } else {
+        let msg = format!("Session not found for IP {}", ip);
+        warn!("{}", msg);
+        Ok(Response::Error(msg))
+    }
+}
+
+async fn handle_connection(
+    mut stream: UnixStream,
+    session_manager: Arc<SessionManager>,
+    radius_client: Arc<RadiusClient>,
+    firewall: Arc<Firewall>,
+) -> Result<()> {
+    info!("Accepted new cmdsock connection");
+
+    let mut buffer = Vec::new();
+    stream.read_to_end(&mut buffer).await?;
+
+    let response = match serde_json::from_slice::<Command>(&buffer) {
+        Ok(Command::List) => {
+            info!("Received List command");
+            let sessions = session_manager.get_all_sessions().await;
+            Response::List(sessions)
+        }
+        Ok(Command::Disconnect { ip }) => {
+            match handle_disconnect(ip, session_manager, radius_client, firewall).await {
+                Ok(resp) => resp,
+                Err(e) => Response::Error(e.to_string()),
+            }
+        }
+        Err(e) => {
+            warn!("Failed to deserialize command: {}", e);
+            Response::Error(format!("Deserialization failed: {}", e))
+        }
+    };
+
+    let serialized = serde_json::to_vec(&response)?;
+    stream.write_all(&serialized).await?;
+    stream.shutdown().await?;
+
+    Ok(())
+}
+
+pub async fn run_cmdsock_listener(
+    path: String,
+    session_manager: Arc<SessionManager>,
+    radius_client: Arc<RadiusClient>,
+    firewall: Arc<Firewall>,
+) -> Result<()> {
+    let socket_path = Path::new(&path);
+
+    // Remove the socket file if it already exists
+    if socket_path.exists() {
+        std::fs::remove_file(socket_path)?;
+    }
+
+    let listener = UnixListener::bind(&path)?;
+    info!("Cmdsock listener started on {}", path);
+
+    loop {
+        match listener.accept().await {
+            Ok((stream, _addr)) => {
+                let session_manager = session_manager.clone();
+                let radius_client = radius_client.clone();
+                let firewall = firewall.clone();
+                tokio::spawn(async move {
+                    if let Err(e) =
+                        handle_connection(stream, session_manager, radius_client, firewall).await
+                    {
+                        error!("Error handling cmdsock connection: {}", e);
+                    }
+                });
+            }
+            Err(e) => {
+                error!("Cmdsock accept error: {}", e);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chilli_core::Config;
+    use std::fs;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::UnixStream;
+
+    // Helper to create a default config for testing
+    fn default_test_config() -> Config {
+        let toml_str = r#"
+            foreground = true
+            debug = true
+            logfacility = 1
+            loglevel = 7
+            interval = 3600
+            pidfile = "/tmp/chilli.pid"
+            statedir = "/tmp/chilli"
+            net = "192.168.1.0"
+            mask = "255.255.255.0"
+            dns1 = "8.8.8.8"
+            dns2 = "8.8.4.4"
+            radiuslisten = "127.0.0.1"
+            radiusserver1 = "127.0.0.1"
+            radiusserver2 = "127.0.0.1"
+            radiussecret = "secret"
+            radiusauthport = 1812
+            radiusacctport = 1813
+            dhcpif = "eth0"
+            dhcplisten = "192.168.1.1"
+            dhcpstart = "192.168.1.10"
+            dhcpend = "192.168.1.20"
+            lease = 3600
+            uamlisten = "192.168.1.1"
+            uamport = 3990
+            max_clients = 10
+            cmdsocket = "/tmp/chilli-test.sock"
+        "#;
+        toml::from_str(toml_str).unwrap()
+    }
+
+    async fn send_test_command(path: &str, command: Command) -> Result<Response> {
+        let mut stream = UnixStream::connect(path).await?;
+        let serialized = serde_json::to_vec(&command)?;
+        stream.write_all(&serialized).await?;
+        stream.shutdown().await?;
+        let mut buffer = Vec::new();
+        stream.read_to_end(&mut buffer).await?;
+        Ok(serde_json::from_slice(&buffer)?)
+    }
+
+    #[tokio::test]
+    async fn test_cmdsock_list_and_disconnect() -> Result<()> {
+        let config = Arc::new(default_test_config());
+        let socket_path = config.cmdsocket.as_ref().unwrap().clone();
+
+        let session_manager = Arc::new(SessionManager::new());
+        let radius_client = Arc::new(RadiusClient::new(config.clone()).await?);
+        let firewall = Arc::new(Firewall::new(config.as_ref().clone()));
+
+        let listener_task = tokio::spawn(run_cmdsock_listener(
+            socket_path.clone(),
+            session_manager.clone(),
+            radius_client.clone(),
+            firewall.clone(),
+        ));
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        // 1. List sessions, should be empty
+        let response = send_test_command(&socket_path, Command::List).await?;
+        match response {
+            Response::List(sessions) => assert!(sessions.is_empty()),
+            _ => panic!("Expected Response::List"),
+        }
+
+        // 2. Create a session
+        let test_ip: Ipv4Addr = "192.168.1.10".parse()?;
+        let test_mac = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55];
+        session_manager
+            .create_session(test_ip, test_mac, &config)
+            .await;
+        session_manager.authenticate_session(&test_ip).await;
+
+        // 3. List sessions, should have one
+        let response = send_test_command(&socket_path, Command::List).await?;
+        match response {
+            Response::List(sessions) => {
+                assert_eq!(sessions.len(), 1);
+                assert_eq!(sessions[0].hisip, test_ip);
+            }
+            _ => panic!("Expected Response::List with one session"),
+        }
+
+        // 4. Disconnect the session
+        let response = send_test_command(&socket_path, Command::Disconnect { ip: test_ip }).await?;
+        match response {
+            Response::Success => {} // Expected
+            _ => panic!("Expected Response::Success"),
+        }
+
+        // 5. List sessions, should be empty again
+        let response = send_test_command(&socket_path, Command::List).await?;
+        match response {
+            Response::List(sessions) => assert!(sessions.is_empty()),
+            _ => panic!("Expected Response::List to be empty after disconnect"),
+        }
+
+        // Cleanup
+        listener_task.abort();
+        fs::remove_file(&socket_path)?;
+
+        Ok(())
+    }
+}

--- a/coovachilli-rust/chilli-core/src/lib.rs
+++ b/coovachilli-rust/chilli-core/src/lib.rs
@@ -4,7 +4,7 @@ pub mod session;
 use std::net::Ipv4Addr;
 
 pub use config::Config;
-pub use session::{Connection, SessionManager, SessionParams, SessionState};
+pub use session::{RedirState, Session, SessionManager, SessionParams, SessionState};
 
 use tokio::sync::oneshot;
 

--- a/coovachilli-rust/chilli-ipc/Cargo.toml
+++ b/coovachilli-rust/chilli-ipc/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "chilli-ipc"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+chilli-core = { path = "../chilli-core" }
+serde = { version = "1.0", features = ["derive"] }

--- a/coovachilli-rust/chilli-ipc/src/lib.rs
+++ b/coovachilli-rust/chilli-ipc/src/lib.rs
@@ -1,0 +1,16 @@
+use chilli_core::Session;
+use serde::{Deserialize, Serialize};
+use std::net::Ipv4Addr;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum Command {
+    List,
+    Disconnect { ip: Ipv4Addr },
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum Response {
+    List(Vec<Session>),
+    Success,
+    Error(String),
+}

--- a/coovachilli-rust/chilli-net/src/radius.rs
+++ b/coovachilli-rust/chilli-net/src/radius.rs
@@ -199,23 +199,23 @@ impl RadiusClient {
         }
     }
 
-    pub async fn send_acct_start(&self, session: &chilli_core::Connection) -> Result<()> {
+    pub async fn send_acct_start(&self, session: &chilli_core::Session) -> Result<()> {
         self.send_acct_packet(session, ACCT_STATUS_TYPE_START)
             .await
     }
 
-    pub async fn send_acct_stop(&self, session: &chilli_core::Connection) -> Result<()> {
+    pub async fn send_acct_stop(&self, session: &chilli_core::Session) -> Result<()> {
         self.send_acct_packet(session, ACCT_STATUS_TYPE_STOP).await
     }
 
-    pub async fn send_acct_interim_update(&self, session: &chilli_core::Connection) -> Result<()> {
+    pub async fn send_acct_interim_update(&self, session: &chilli_core::Session) -> Result<()> {
         self.send_acct_packet(session, ACCT_STATUS_TYPE_INTERIM_UPDATE)
             .await
     }
 
     async fn send_acct_packet(
         &self,
-        session: &chilli_core::Connection,
+        session: &chilli_core::Session,
         status_type: u32,
     ) -> Result<()> {
         let packet_id = {

--- a/coovachilli-rust/chilli-query/Cargo.toml
+++ b/coovachilli-rust/chilli-query/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "chilli-query"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+chilli-ipc = { path = "../chilli-ipc" }
+tokio = { version = "1", features = ["full"] }
+serde_json = "1.0"
+clap = { version = "4.0", features = ["derive"] }
+anyhow = "1.0"

--- a/coovachilli-rust/chilli-query/src/main.rs
+++ b/coovachilli-rust/chilli-query/src/main.rs
@@ -1,0 +1,103 @@
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use chilli_ipc::{Command, Response};
+use std::net::Ipv4Addr;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+
+const CMDSOCK_PATH: &str = "/tmp/chilli.sock";
+
+#[derive(Parser, Debug)]
+#[clap(author, version, about, long_about = None)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    /// List active sessions
+    List,
+    /// Disconnect a session by IP address
+    Disconnect {
+        #[clap(value_parser)]
+        ip: Ipv4Addr,
+    },
+}
+
+async fn send_command(command: Command) -> Result<Response> {
+    let mut stream = UnixStream::connect(CMDSOCK_PATH).await?;
+    let serialized = serde_json::to_vec(&command)?;
+
+    stream.write_all(&serialized).await?;
+    stream.shutdown().await?; // Half-close the stream
+
+    let mut buffer = Vec::new();
+    stream.read_to_end(&mut buffer).await?;
+
+    let response: Response = serde_json::from_slice(&buffer)?;
+    Ok(response)
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    match &cli.command {
+        Commands::List => {
+            let response = send_command(Command::List).await?;
+            match response {
+                Response::List(sessions) => {
+                    println!(
+                        "{:<15} {:<17} {:<12} {:<10} {:<10}",
+                        "IP Address", "MAC Address", "Username", "State", "Session ID"
+                    );
+                    println!("{:-<75}", "");
+                    for session in sessions {
+                        let username = session.state.redir.username.as_deref().unwrap_or("-");
+                        let state = if session.state.authenticated {
+                            "AUTH"
+                        } else {
+                            "NOAUTH"
+                        };
+                        println!(
+                            "{:<15} {:02X}:{:02X}:{:02X}:{:02X}:{:02X}:{:02X} {:<12} {:<10} {:<10}",
+                            session.hisip,
+                            session.hismac[0],
+                            session.hismac[1],
+                            session.hismac[2],
+                            session.hismac[3],
+                            session.hismac[4],
+                            session.hismac[5],
+                            username,
+                            state,
+                            session.state.sessionid,
+                        );
+                    }
+                }
+                Response::Error(e) => {
+                    eprintln!("Server error: {}", e);
+                }
+                _ => {
+                    eprintln!("Unexpected response from server");
+                }
+            }
+        }
+        Commands::Disconnect { ip } => {
+            let response = send_command(Command::Disconnect { ip: *ip }).await?;
+            match response {
+                Response::Success => {
+                    println!("Successfully disconnected session for IP {}", ip);
+                }
+                Response::Error(e) => {
+                    eprintln!("Failed to disconnect session for IP {}: {}", ip, e);
+                }
+                _ => {
+                    eprintln!("Unexpected response from server");
+                }
+            }
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This commit introduces a command socket feature to the Rust implementation of CoovaChilli, analogous to the `chilli_query` functionality in the C version. This provides a mechanism for runtime inspection and control of the `chilli` daemon.

The implementation includes:
- A new `chilli-ipc` crate that defines the `Command` and `Response` enums for inter-process communication using `serde` for serialization.
- A new `chilli-query` binary crate that provides a command-line tool. It currently supports two subcommands:
    - `list`: To list all active user sessions.
    - `disconnect --ip <IP>`: To terminate a specific user session.
- A new `cmdsock` module in the main `chilli-bin` daemon, which listens on a Unix domain socket for commands from `chilli-query`.
- The `Session` struct in `chilli-core` has been made serializable to allow session data to be transmitted.
- An integration test has been added to verify the `list` and `disconnect` functionality, ensuring the daemon correctly processes commands and manages session state.