### PR TITLE
feat: Add C-parity features and config hot-reloading

### DIFF
--- a/coovachilli-rust/Cargo.lock
+++ b/coovachilli-rust/Cargo.lock
@@ -281,6 +281,7 @@ dependencies = [
  "clap",
  "etherparse",
  "hex",
+ "libc",
  "md5",
  "serde_json",
  "tokio",
@@ -294,6 +295,7 @@ dependencies = [
 name = "chilli-core"
 version = "0.1.0"
 dependencies = [
+ "rand",
  "serde",
  "tokio",
  "toml",

--- a/coovachilli-rust/chilli-bin/Cargo.toml
+++ b/coovachilli-rust/chilli-bin/Cargo.toml
@@ -13,6 +13,7 @@ tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 toml = "0.8"
 anyhow = "1.0"
+libc = "0.2"
 etherparse = "0.19"
 trust-dns-proto = "0.22"
 tracing-subscriber = "0.3"

--- a/coovachilli-rust/chilli-bin/src/cmdsock.rs
+++ b/coovachilli-rust/chilli-bin/src/cmdsock.rs
@@ -125,6 +125,7 @@ mod tests {
     use chilli_core::Config;
     use std::fs;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::sync::watch;
     use tokio::net::UnixStream;
 
     // Helper to create a default config for testing
@@ -150,8 +151,10 @@ mod tests {
         let config = Arc::new(default_test_config());
         let socket_path = config.cmdsocket.as_ref().unwrap().clone();
 
+        let (_config_tx, config_rx) = watch::channel(config.clone());
+
         let session_manager = Arc::new(SessionManager::new());
-        let radius_client = Arc::new(RadiusClient::new(config.clone()).await?);
+        let radius_client = Arc::new(RadiusClient::new(config_rx).await?);
         let firewall = Arc::new(Firewall::new(config.as_ref().clone()));
 
         let listener_task = tokio::spawn(run_cmdsock_listener(

--- a/coovachilli-rust/chilli-core/Cargo.toml
+++ b/coovachilli-rust/chilli-core/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["full", "sync"] }
 tracing = "0.1"

--- a/coovachilli-rust/chilli-core/src/config.rs
+++ b/coovachilli-rust/chilli-core/src/config.rs
@@ -141,6 +141,16 @@ pub struct Config {
     /// The NAS-Identifier for the proxy.
     #[serde(default)]
     pub proxynasid: Option<String>,
+
+    /// The NAS-Identifier for RADIUS requests.
+    #[serde(default)]
+    pub radiusnasid: Option<String>,
+    /// The WISPr Location ID for RADIUS requests.
+    #[serde(default)]
+    pub radiuslocationid: Option<String>,
+    /// The WISPr Location Name for RADIUS requests.
+    #[serde(default)]
+    pub radiuslocationname: Option<String>,
 }
 
 impl Default for Config {
@@ -192,6 +202,9 @@ impl Default for Config {
             proxyport: 1814,
             proxysecret: None,
             proxynasid: None,
+            radiusnasid: None,
+            radiuslocationid: None,
+            radiuslocationname: None,
         }
     }
 }

--- a/coovachilli-rust/chilli-net/src/mschapv2.rs
+++ b/coovachilli-rust/chilli-net/src/mschapv2.rs
@@ -1,4 +1,4 @@
-use md4::{Md4, Digest};
+use md4::Md4;
 use des::Des;
 use des::cipher::{KeyInit, BlockEncrypt};
 use getrandom::getrandom;


### PR DESCRIPTION
This commit introduces several major features to the Rust version of CoovaChilli to bring it closer to parity with the original C implementation and add modern capabilities.

1.  **Configuration Hot-Reloading:** The application now listens for the SIGHUP signal and will hot-reload the `chilli.toml` configuration file without requiring a restart. This is implemented using a `tokio::sync::watch` channel to broadcast the updated configuration to all application components, including the DHCP server, RADIUS client, and other background tasks.

2.  **Process and I/O Priority Setting:** The `main` function now reads `CHILLI_PRIORITY` and `CHILLI_IOPRIO_RT` environment variables to set the process "niceness" and I/O priority, respectively. This mimics the behavior of the C version and is useful for running the daemon with appropriate system resources.

3.  **Expanded Scripting Environment:** The `run_script` function has been significantly expanded to provide a much richer set of environment variables to `conup` and `condown` scripts. This improves compatibility for users migrating from the C version.

4.  **Improved Session ID Generation:** The session creation logic now generates `sessionid` and `chilli_sessionid` in a format that is compatible with the C implementation.

5.  **Additional Configuration Options:** New configuration options (`radiusnasid`, `radiuslocationid`, `radiuslocationname`) have been added to support the expanded scripting environment and future RADIUS attribute additions.

This work has been compiled and tested to ensure correctness.