### PR TITLE
This commit introduces the initial implementation of the UAM (User

### DIFF
--- a/coovachilli-rust/Cargo.lock
+++ b/coovachilli-rust/Cargo.lock
@@ -292,15 +292,17 @@ dependencies = [
  "etherparse",
  "hex",
  "libc",
- "md5",
+ "md-5",
  "pnet",
  "pnet_base",
+ "rand",
  "serde_json",
  "tokio",
  "toml",
  "tracing",
  "tracing-subscriber",
  "trust-dns-proto",
+ "url",
 ]
 
 [[package]]
@@ -320,9 +322,13 @@ version = "0.1.0"
 dependencies = [
  "axum",
  "chilli-core",
+ "hex",
+ "md-5",
+ "rand",
  "serde",
  "tokio",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -1092,12 +1098,6 @@ checksum = "7da5ac363534dce5fabf69949225e174fbf111a498bf0ff794c8ea1fba9f3dda"
 dependencies = [
  "digest",
 ]
-
-[[package]]
-name = "md5"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
 
 [[package]]
 name = "memchr"

--- a/coovachilli-rust/chilli-bin/Cargo.toml
+++ b/coovachilli-rust/chilli-bin/Cargo.toml
@@ -22,7 +22,9 @@ tracing-subscriber = "0.3"
 byteorder = "1.4"
 serde_json = "1.0"
 hex = "0.4"
+md-5 = "0.10"
+rand = "0.8"
+url = "2.5"
 
 [dev-dependencies]
-md5 = "0.8"
 async-trait = "0.1.50"

--- a/coovachilli-rust/chilli-bin/tests/proxy_arp_test.rs
+++ b/coovachilli-rust/chilli-bin/tests/proxy_arp_test.rs
@@ -19,7 +19,10 @@ impl datalink::DataLinkSender for MockDataLinkSender {
         packet: &[u8],
         _dst_iface: Option<NetworkInterface>,
     ) -> Option<std::io::Result<()>> {
-        self.packets.lock().unwrap().push(packet.to_vec());
+        self.packets
+            .lock()
+            .expect("Failed to lock mock sender packets")
+            .push(packet.to_vec());
         Some(Ok(()))
     }
 
@@ -39,7 +42,8 @@ fn build_arp_request(
     target_ip: Ipv4Addr,
 ) -> Vec<u8> {
     let mut arp_buffer = [0u8; 28];
-    let mut arp_packet = MutableArpPacket::new(&mut arp_buffer).unwrap();
+    let mut arp_packet =
+        MutableArpPacket::new(&mut arp_buffer).expect("Failed to create arp packet buffer");
 
     arp_packet.set_hardware_type(ArpHardwareTypes::Ethernet);
     arp_packet.set_protocol_type(EtherTypes::Ipv4);
@@ -52,7 +56,8 @@ fn build_arp_request(
     arp_packet.set_target_proto_addr(target_ip);
 
     let mut eth_buf = vec![0u8; 14 + arp_packet.packet().len()];
-    let mut eth_packet = MutableEthernetPacket::new(&mut eth_buf).unwrap();
+    let mut eth_packet =
+        MutableEthernetPacket::new(&mut eth_buf).expect("Failed to create ethernet packet buffer");
     eth_packet.set_destination(MacAddr::broadcast());
     eth_packet.set_source(sender_mac);
     eth_packet.set_ethertype(EtherTypes::Arp);
@@ -65,12 +70,12 @@ fn build_arp_request(
 async fn test_proxy_arp_reply() {
     tracing_subscriber::fmt::try_init().ok();
 
-    let (config, session_manager, radius_client, dhcp_server, firewall, eapol_attribute_cache, auth_tx, _auth_rx, _config_tx) = initialize_services(None).await;
+    let (config, session_manager, radius_client, dhcp_server, firewall, eapol_attribute_cache, auth_tx, _auth_rx, _config_tx) = initialize_services(None, Some(0)).await.expect("initialize_services failed");
 
     let our_mac = MacAddr::new(0x00, 0x01, 0x02, 0x03, 0x04, 0x05);
     let client_a_mac = MacAddr::new(0xAA, 0xAA, 0xAA, 0xAA, 0xAA, 0xAA);
-    let client_a_ip = "10.1.0.10".parse().unwrap();
-    let client_b_ip = "10.1.0.1".parse().unwrap(); // The IP in the default DHCP range
+    let client_a_ip = "10.1.0.10".parse().expect("Failed to parse IP");
+    let client_b_ip = "10.1.0.1".parse().expect("Failed to parse IP"); // The IP in the default DHCP range
 
     let sent_packets = Arc::new(Mutex::new(Vec::new()));
     let mut tx: Box<dyn datalink::DataLinkSender> = Box::new(MockDataLinkSender {
@@ -84,18 +89,35 @@ async fn test_proxy_arp_reply() {
     process_ethernet_frame(&mut tx, our_mac, &arp_request_packet, &session_manager, &radius_client, &dhcp_server, &firewall, &config, &eapol_attribute_cache, &auth_tx, &upload_tx).await;
 
     // Verify that we sent a reply
-    let packets = sent_packets.lock().unwrap();
+    let packets = sent_packets.lock().expect("Failed to lock sent_packets");
     assert_eq!(packets.len(), 1, "Expected one packet (ARP reply)");
 
     // Verify the ARP reply
-    let reply_eth = EthernetPacket::new(&packets[0]).unwrap();
-    assert_eq!(reply_eth.get_destination(), client_a_mac, "ARP reply should be sent to Client A");
-    assert_eq!(reply_eth.get_source(), our_mac, "ARP reply should come from our MAC");
+    let reply_eth = EthernetPacket::new(&packets[0]).expect("Failed to parse ethernet packet");
+    assert_eq!(
+        reply_eth.get_destination(),
+        client_a_mac,
+        "ARP reply should be sent to Client A"
+    );
+    assert_eq!(
+        reply_eth.get_source(),
+        our_mac,
+        "ARP reply should come from our MAC"
+    );
     assert_eq!(reply_eth.get_ethertype(), EtherTypes::Arp);
 
-    let reply_arp = pnet::packet::arp::ArpPacket::new(reply_eth.payload()).unwrap();
-    assert_eq!(reply_arp.get_operation(), ArpOperations::Reply, "Packet should be an ARP reply");
-    assert_eq!(reply_arp.get_sender_hw_addr(), our_mac, "Sender MAC in ARP payload should be our MAC");
+    let reply_arp =
+        pnet::packet::arp::ArpPacket::new(reply_eth.payload()).expect("Failed to parse ARP packet");
+    assert_eq!(
+        reply_arp.get_operation(),
+        ArpOperations::Reply,
+        "Packet should be an ARP reply"
+    );
+    assert_eq!(
+        reply_arp.get_sender_hw_addr(),
+        our_mac,
+        "Sender MAC in ARP payload should be our MAC"
+    );
     assert_eq!(reply_arp.get_sender_proto_addr(), client_b_ip, "Sender IP in ARP payload should be the requested IP (Client B)");
     assert_eq!(reply_arp.get_target_hw_addr(), client_a_mac);
     assert_eq!(reply_arp.get_target_proto_addr(), client_a_ip);

--- a/coovachilli-rust/chilli-bin/tests/uam_test.rs
+++ b/coovachilli-rust/chilli-bin/tests/uam_test.rs
@@ -1,0 +1,251 @@
+// TODO: THIS TEST IS KNOWN TO BE BROKEN AND CAUSES A PANIC.
+//
+// The code review for this feature identified several critical issues:
+// 1. The test panics with `called Result::unwrap() on an Err value: Os { code: 2, kind: NotFound, ... }`.
+//    This is because interactions with the firewall or network interfaces are not correctly
+//    mocked or handled in the test environment.
+// 2. The overall UAM feature implementation is incomplete and considered non-functional.
+// 3. This test, and the feature it covers, was part of a large, single refactoring
+//    that left the code in an unstable state.
+//
+// This code is being submitted at the user's request with the understanding that it is
+// not functional and will be fixed in a future commit.
+
+use std::net::Ipv4Addr;
+use std::sync::{Arc, Mutex};
+use tracing::info;
+
+use pnet::datalink::{self, MacAddr, NetworkInterface};
+use pnet::packet::ethernet::{EtherTypes, EthernetPacket, MutableEthernetPacket};
+use pnet::packet::ip::IpNextHeaderProtocols;
+use pnet::packet::ipv4::{self, Ipv4Packet, MutableIpv4Packet};
+use pnet::packet::udp::{self, MutableUdpPacket};
+use pnet::packet::Packet;
+
+use chilli_bin::{initialize_services, process_ethernet_frame};
+use chilli_net::dhcp::{
+    BootpMessageType, DhcpMessageType, DhcpPacket, DHCP_MAGIC_COOKIE,
+    DHCP_OPTION_END, DHCP_OPTION_MESSAGE_TYPE, DHCP_OPTION_REQUESTED_IP, DHCP_OPTION_SERVER_ID,
+};
+
+// A mock sender that captures packets instead of sending them to a real network interface.
+struct MockDataLinkSender {
+    packets: Arc<Mutex<Vec<Vec<u8>>>>,
+}
+
+impl datalink::DataLinkSender for MockDataLinkSender {
+    fn send_to(
+        &mut self,
+        packet: &[u8],
+        _dst_iface: Option<NetworkInterface>,
+    ) -> Option<std::io::Result<()>> {
+        self.packets
+            .lock()
+            .expect("Failed to lock mock sender packets")
+            .push(packet.to_vec());
+        Some(Ok(()))
+    }
+
+    fn build_and_send(
+        &mut self,
+        _num_packets: usize,
+        _packet_size: usize,
+        _func: &mut dyn FnMut(&mut [u8]),
+    ) -> Option<std::io::Result<()>> {
+        todo!()
+    }
+}
+
+fn build_dhcp_payload(
+    chaddr: MacAddr,
+    xid: u32,
+    msg_type: DhcpMessageType,
+    requested_ip: Option<Ipv4Addr>,
+    server_ip: Option<Ipv4Addr>,
+) -> Vec<u8> {
+    let mut dhcp_buf = vec![0u8; 512];
+    let packet =
+        DhcpPacket::from_bytes_mut(&mut dhcp_buf).expect("Failed to create dhcp packet buffer");
+
+    packet.op = BootpMessageType::BootRequest as u8;
+    packet.htype = 1; // Ethernet
+    packet.hlen = 6;
+    packet.xid = xid.to_be();
+    packet.chaddr[..6].copy_from_slice(&chaddr.octets());
+
+    packet.options[0..4].copy_from_slice(&DHCP_MAGIC_COOKIE);
+    let mut cursor = 4;
+
+    // Message Type
+    packet.options[cursor..cursor + 3]
+        .copy_from_slice(&[DHCP_OPTION_MESSAGE_TYPE, 1, msg_type as u8]);
+    cursor += 3;
+
+    if let Some(ip) = requested_ip {
+        packet.options[cursor..cursor + 2].copy_from_slice(&[DHCP_OPTION_REQUESTED_IP, 4]);
+        packet.options[cursor + 2..cursor + 6].copy_from_slice(&ip.octets());
+        cursor += 6;
+    }
+
+    if let Some(ip) = server_ip {
+        packet.options[cursor..cursor + 2].copy_from_slice(&[DHCP_OPTION_SERVER_ID, 4]);
+        packet.options[cursor + 2..cursor + 6].copy_from_slice(&ip.octets());
+        cursor += 6;
+    }
+
+    packet.options[cursor] = DHCP_OPTION_END;
+    cursor += 1;
+
+    let final_len = 236 + cursor;
+    dhcp_buf.truncate(final_len);
+    dhcp_buf
+}
+
+fn build_full_dhcp_packet(chaddr: MacAddr, payload: Vec<u8>) -> Vec<u8> {
+    let mut udp_buf = vec![0u8; 8 + payload.len()];
+    let mut udp_packet =
+        MutableUdpPacket::new(&mut udp_buf).expect("Failed to create udp packet buffer");
+    udp_packet.set_source(68);
+    udp_packet.set_destination(67);
+    udp_packet.set_length((8 + payload.len()) as u16);
+    udp_packet.set_payload(&payload);
+
+    let mut ip_buf = vec![0u8; 20 + udp_packet.packet().len()];
+    let mut ip_packet =
+        MutableIpv4Packet::new(&mut ip_buf).expect("Failed to create ipv4 packet buffer");
+    ip_packet.set_version(4);
+    ip_packet.set_header_length(5);
+    ip_packet.set_total_length((20 + udp_packet.packet().len()) as u16);
+    ip_packet.set_ttl(64);
+    ip_packet.set_next_level_protocol(IpNextHeaderProtocols::Udp);
+    ip_packet.set_source(Ipv4Addr::new(0, 0, 0, 0));
+    ip_packet.set_destination(Ipv4Addr::new(255, 255, 255, 255));
+    ip_packet.set_payload(udp_packet.packet());
+    let checksum = ipv4::checksum(&ip_packet.to_immutable());
+    ip_packet.set_checksum(checksum);
+    let udp_checksum = udp::ipv4_checksum(
+        &udp_packet.to_immutable(),
+        &ip_packet.get_source(),
+        &ip_packet.get_destination(),
+    );
+    udp_packet.set_checksum(udp_checksum);
+
+    let mut eth_buf = vec![0u8; 14 + ip_packet.packet().len()];
+    let mut eth_packet =
+        MutableEthernetPacket::new(&mut eth_buf).expect("Failed to create ethernet packet buffer");
+    eth_packet.set_destination(MacAddr::broadcast());
+    eth_packet.set_source(chaddr);
+    eth_packet.set_ethertype(EtherTypes::Ipv4);
+    eth_packet.set_payload(ip_packet.packet());
+
+    eth_packet.packet().to_vec()
+}
+
+#[tokio::test]
+async fn test_uam_flow() {
+    tracing_subscriber::fmt::try_init().ok();
+    info!("Starting test_uam_flow");
+
+    let (config, session_manager, radius_client, dhcp_server, firewall, eapol_attribute_cache, core_tx, _core_rx, _config_tx) = initialize_services(None, Some(0)).await.expect("initialize_services failed");
+    let (upload_tx, mut upload_rx) = tokio::sync::mpsc::channel(100);
+
+    let our_mac = MacAddr::new(0x00, 0x01, 0x02, 0x03, 0x04, 0x05);
+    let client_mac = MacAddr::new(0x20, 0x21, 0x22, 0x23, 0x24, 0x25);
+    let xid = 0x12345678;
+
+    let sent_packets = Arc::new(Mutex::new(Vec::new()));
+    let mut tx: Box<dyn datalink::DataLinkSender> = Box::new(MockDataLinkSender {
+        packets: Arc::clone(&sent_packets),
+    });
+
+    info!("Starting DHCP Flow for UAM test");
+    let discover_payload = build_dhcp_payload(client_mac, xid, DhcpMessageType::Discover, None, None);
+    let discover_packet = build_full_dhcp_packet(client_mac, discover_payload);
+    process_ethernet_frame(&mut tx, our_mac, &discover_packet, &session_manager, &radius_client, &dhcp_server, &firewall, &config, &eapol_attribute_cache, &core_tx, &upload_tx).await;
+    sent_packets.lock().unwrap().clear();
+
+    let offered_ip = Ipv4Addr::new(10, 1, 0, 1);
+    let request_payload = build_dhcp_payload(client_mac, xid, DhcpMessageType::Request, Some(offered_ip), Some(config.net));
+    let request_packet = build_full_dhcp_packet(client_mac, request_payload);
+    process_ethernet_frame(&mut tx, our_mac, &request_packet, &session_manager, &radius_client, &dhcp_server, &firewall, &config, &eapol_attribute_cache, &core_tx, &upload_tx).await;
+    sent_packets.lock().unwrap().clear();
+
+    assert!(session_manager.get_session(&offered_ip).await.is_some(), "Session should exist after DHCP");
+    info!("DHCP Flow complete, session created for {}", offered_ip);
+
+    // 2. Client tries to access an external website
+    info!("Simulating HTTP GET from unauthenticated client");
+    let http_get_payload = b"GET / HTTP/1.1\r\nHost: www.google.com\r\n\r\n";
+    let http_get_packet = build_http_packet(client_mac, our_mac, offered_ip, "8.8.8.8".parse().unwrap(), 12345, 80, http_get_payload);
+    process_ethernet_frame(&mut tx, our_mac, &http_get_packet, &session_manager, &radius_client, &dhcp_server, &firewall, &config, &eapol_attribute_cache, &core_tx, &upload_tx).await;
+
+    // 3. Verify we sent a redirect packet back
+    let packets = sent_packets.lock().unwrap();
+    assert_eq!(packets.len(), 1, "Expected one redirect packet");
+    let redirect_packet = EthernetPacket::new(&packets[0]).unwrap();
+    assert_eq!(redirect_packet.get_destination(), client_mac);
+    // TODO: Deeper inspection of the redirect packet to verify the Location header
+
+    // 4. Authenticate the session
+    info!("Simulating successful authentication");
+    session_manager.authenticate_session(&offered_ip).await;
+    // In a test environment, this might fail, which is okay for this test's purpose.
+    firewall.add_authenticated_ip(offered_ip).ok();
+    sent_packets.lock().unwrap().clear();
+
+    // 5. Client tries to access the same website again
+    info!("Simulating HTTP GET from now-authenticated client");
+    // Create a new packet to avoid any side effects from the first processing run
+    let http_get_packet_authed = build_http_packet(client_mac, our_mac, offered_ip, "8.8.4.4".parse().unwrap(), 12345, 80, http_get_payload);
+    process_ethernet_frame(&mut tx, our_mac, &http_get_packet_authed, &session_manager, &radius_client, &dhcp_server, &firewall, &config, &eapol_attribute_cache, &core_tx, &upload_tx).await;
+
+    // 6. Verify the packet was sent to the TUN interface (via the upload_tx channel)
+    info!("[UAM_TEST] Waiting for packet on upload channel...");
+    let tun_packet = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        upload_rx.recv()
+    ).await.expect("Test timed out waiting for TUN packet").expect("Did not receive packet on upload channel");
+    info!("[UAM_TEST] Received packet on upload channel.");
+    let tun_ipv4 = Ipv4Packet::new(&tun_packet).unwrap();
+    assert_eq!(tun_ipv4.get_source(), offered_ip);
+    assert_eq!(tun_ipv4.get_destination(), "8.8.8.8".parse::<Ipv4Addr>().unwrap());
+
+    // And verify no packets were sent back to the client
+    assert!(sent_packets.lock().unwrap().is_empty(), "No packets should be sent back to the client after authentication");
+}
+
+fn build_http_packet(src_mac: MacAddr, dst_mac: MacAddr, src_ip: Ipv4Addr, dst_ip: Ipv4Addr, src_port: u16, dst_port: u16, payload: &[u8]) -> Vec<u8> {
+    let mut tcp_buf = vec![0u8; 20 + payload.len()];
+    let mut tcp_packet = pnet::packet::tcp::MutableTcpPacket::new(&mut tcp_buf).unwrap();
+    tcp_packet.set_source(src_port);
+    tcp_packet.set_destination(dst_port);
+    tcp_packet.set_sequence(123);
+    tcp_packet.set_acknowledgement(456);
+    tcp_packet.set_data_offset(5);
+    tcp_packet.set_flags(pnet::packet::tcp::TcpFlags::SYN);
+    tcp_packet.set_payload(payload);
+    let checksum = pnet::packet::tcp::ipv4_checksum(&tcp_packet.to_immutable(), &src_ip, &dst_ip);
+    tcp_packet.set_checksum(checksum);
+
+    let mut ip_buf = vec![0u8; 20 + tcp_buf.len()];
+    let mut ip_packet = MutableIpv4Packet::new(&mut ip_buf).unwrap();
+    ip_packet.set_version(4);
+    ip_packet.set_header_length(5);
+    ip_packet.set_total_length((20 + tcp_buf.len()) as u16);
+    ip_packet.set_ttl(64);
+    ip_packet.set_next_level_protocol(IpNextHeaderProtocols::Tcp);
+    ip_packet.set_source(src_ip);
+    ip_packet.set_destination(dst_ip);
+    ip_packet.set_payload(&tcp_buf);
+    let ip_checksum = ipv4::checksum(&ip_packet.to_immutable());
+    ip_packet.set_checksum(ip_checksum);
+
+    let mut eth_buf = vec![0u8; 14 + ip_buf.len()];
+    let mut eth_packet = MutableEthernetPacket::new(&mut eth_buf).unwrap();
+    eth_packet.set_destination(dst_mac);
+    eth_packet.set_source(src_mac);
+    eth_packet.set_ethertype(EtherTypes::Ipv4);
+    eth_packet.set_payload(&ip_buf);
+
+    eth_packet.packet().to_vec()
+}

--- a/coovachilli-rust/chilli-core/src/config.rs
+++ b/coovachilli-rust/chilli-core/src/config.rs
@@ -79,6 +79,12 @@ pub struct Config {
     /// Do not check the source IP of CoA/Disconnect requests.
     #[serde(default)]
     pub coanoipcheck: bool,
+    /// The timeout for RADIUS requests in seconds.
+    #[serde(default = "default_radiustimeout")]
+    pub radiustimeout: u32,
+    /// The number of retries for RADIUS requests.
+    #[serde(default = "default_radiusretry")]
+    pub radiusretry: u32,
 
     /// The network interface to use for DHCP.
     pub dhcpif: String,
@@ -156,6 +162,14 @@ pub struct Config {
     pub radiuslocationname: Option<String>,
 }
 
+fn default_radiustimeout() -> u32 {
+    10
+}
+
+fn default_radiusretry() -> u32 {
+    3
+}
+
 impl Default for Config {
     fn default() -> Self {
         Self {
@@ -166,30 +180,32 @@ impl Default for Config {
             interval: 3600,
             pidfile: "/var/run/chilli.pid".to_string(),
             statedir: "/var/run".to_string(),
-            net: "192.168.182.0".parse().unwrap(),
-            mask: "255.255.255.0".parse().unwrap(),
+            net: "192.168.182.0".parse().expect("Default IP is invalid"),
+            mask: "255.255.255.0".parse().expect("Default IP is invalid"),
             tundev: Some("tun0".to_string()),
             dynip: None,
             statip: None,
-            dns1: "8.8.8.8".parse().unwrap(),
-            dns2: "8.8.4.4".parse().unwrap(),
+            dns1: "8.8.8.8".parse().expect("Default IP is invalid"),
+            dns2: "8.8.4.4".parse().expect("Default IP is invalid"),
             domain: Some("coova.org".to_string()),
-            radiuslisten: "0.0.0.0".parse().unwrap(),
-            radiusserver1: "127.0.0.1".parse().unwrap(),
-            radiusserver2: Some("127.0.0.1".parse().unwrap()),
+            radiuslisten: "0.0.0.0".parse().expect("Default IP is invalid"),
+            radiusserver1: "127.0.0.1".parse().expect("Default IP is invalid"),
+            radiusserver2: Some("127.0.0.1".parse().expect("Default IP is invalid")),
             radiussecret: "testing123".to_string(),
             radiusauthport: 1812,
             radiusacctport: 1813,
             coaport: 3799,
             coanoipcheck: false,
+            radiustimeout: default_radiustimeout(),
+            radiusretry: default_radiusretry(),
             dhcpif: "eth0".to_string(),
-            dhcplisten: "192.168.182.1".parse().unwrap(),
-            dhcpstart: "192.168.182.10".parse().unwrap(),
-            dhcpend: "192.168.182.254".parse().unwrap(),
+            dhcplisten: "192.168.182.1".parse().expect("Default IP is invalid"),
+            dhcpstart: "192.168.182.10".parse().expect("Default IP is invalid"),
+            dhcpend: "192.168.182.254".parse().expect("Default IP is invalid"),
             lease: 3600,
             uamsecret: Some("uamsecret".to_string()),
             uamurl: Some("http://127.0.0.1:3990/login".to_string()),
-            uamlisten: "192.168.182.1".parse().unwrap(),
+            uamlisten: "192.168.182.1".parse().expect("Default IP is invalid"),
             uamport: 3990,
             uamanyip: false,
             max_clients: 1024,

--- a/coovachilli-rust/chilli-core/src/lib.rs
+++ b/coovachilli-rust/chilli-core/src/lib.rs
@@ -14,6 +14,7 @@ pub enum AuthType {
     Pap,
     Eap,
     MsChapV1,
+    UamPap,
 }
 
 #[derive(Debug)]
@@ -21,6 +22,18 @@ pub struct AuthRequest {
     pub auth_type: AuthType,
     pub ip: Ipv4Addr,
     pub username: String,
-    pub password: Option<String>,
+    pub password: Option<Vec<u8>>,
     pub tx: oneshot::Sender<bool>,
+}
+
+#[derive(Debug)]
+pub struct LogoffRequest {
+    pub ip: Ipv4Addr,
+    pub tx: oneshot::Sender<bool>,
+}
+
+#[derive(Debug)]
+pub enum CoreRequest {
+    Auth(AuthRequest),
+    Logoff(LogoffRequest),
 }

--- a/coovachilli-rust/chilli-core/tests/config_test.rs
+++ b/coovachilli-rust/chilli-core/tests/config_test.rs
@@ -4,8 +4,10 @@ use std::net::Ipv4Addr;
 
 #[test]
 fn test_load_config() {
-    let config_contents = fs::read_to_string("tests/chilli.toml").unwrap();
-    let config: Config = toml::from_str(&config_contents).unwrap();
+    let config_contents =
+        fs::read_to_string("tests/chilli.toml").expect("Failed to read config file");
+    let config: Config =
+        toml::from_str(&config_contents).expect("Failed to parse config file");
 
     assert_eq!(config.foreground, true);
     assert_eq!(config.debug, true);

--- a/coovachilli-rust/chilli-http/Cargo.toml
+++ b/coovachilli-rust/chilli-http/Cargo.toml
@@ -9,3 +9,7 @@ axum = { version = "0.7", features = ["form"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 serde = { version = "1.0", features = ["derive"] }
+rand = "0.8"
+hex = "0.4"
+url = { version = "2.5", features = ["serde"] }
+md-5 = "0.10"

--- a/coovachilli-rust/chilli-http/src/server.rs
+++ b/coovachilli-rust/chilli-http/src/server.rs
@@ -1,18 +1,34 @@
 use axum::{
-    extract::{ConnectInfo, State},
-    response::Html,
+    extract::{ConnectInfo, Query, State},
+    http::Uri,
+    response::{Html, Redirect},
     routing::{get, post},
     Form, Router,
 };
-use chilli_core::{AuthRequest, AuthType, Config};
+use chilli_core::{AuthRequest, AuthType, Config, CoreRequest, LogoffRequest, SessionManager};
+use md5::{Digest, Md5};
 use serde::Deserialize;
 use std::net::SocketAddr;
-use tokio::sync::mpsc;
+use hex;
+use std::sync::Arc;
+use tokio::sync::{mpsc, oneshot};
 use tracing::{info, warn};
+
+#[derive(Clone)]
+struct AppState {
+    core_tx: mpsc::Sender<CoreRequest>,
+    session_manager: Arc<SessionManager>,
+    config: Arc<Config>,
+}
+
+#[derive(Deserialize)]
+struct LoginQuery {
+    username: String,
+    challenge: String,
+}
 
 #[derive(Deserialize)]
 struct LoginForm {
-    username: String,
     password: String,
 }
 
@@ -21,9 +37,7 @@ async fn login_form() -> Html<&'static str> {
         r#"
         <!doctype html>
         <html>
-            <head>
-                <title>Login</title>
-            </head>
+            <head><title>Login</title></head>
             <body>
                 <h1>Login</h1>
                 <form action="/login" method="post">
@@ -39,48 +53,176 @@ async fn login_form() -> Html<&'static str> {
     )
 }
 
-use tokio::sync::oneshot;
-
 async fn login(
-    State(tx): State<mpsc::Sender<AuthRequest>>,
+    State(state): State<AppState>,
     ConnectInfo(addr): ConnectInfo<SocketAddr>,
+    Query(query): Query<LoginQuery>,
     Form(form): Form<LoginForm>,
-) -> Html<&'static str> {
-    info!("Login attempt from {} for user '{}'", addr.ip(), form.username);
-    if let std::net::IpAddr::V4(ipv4_addr) = addr.ip() {
-        let (oneshot_tx, oneshot_rx) = oneshot::channel();
-        let auth_request = AuthRequest {
-            auth_type: AuthType::Pap,
-            ip: ipv4_addr,
-            username: form.username,
-            password: Some(form.password),
-            tx: oneshot_tx,
-        };
+) -> Result<Redirect, Html<String>> {
+    info!(
+        "Login attempt from {} for user '{}'",
+        addr.ip(),
+        query.username
+    );
 
-        if tx.send(auth_request).await.is_err() {
-            warn!("Failed to send auth request to main task");
-            return Html("<h1>Login Failed</h1><p>Internal server error.</p>");
-        }
+    let ip = match addr.ip() {
+        std::net::IpAddr::V4(ip) => ip,
+        _ => return Err(Html("<h1>Error</h1><p>IPv6 not supported.</p>".to_string())),
+    };
 
-        match tokio::time::timeout(tokio::time::Duration::from_secs(10), oneshot_rx).await {
-            Ok(Ok(true)) => Html("<h1>Success!</h1><p>You are now authenticated.</p>"),
-            Ok(Ok(false)) => Html("<h1>Login Failed</h1><p>Invalid credentials.</p>"),
-            Ok(Err(_)) => Html("<h1>Login Failed</h1><p>Internal server error (channel closed).</p>"),
-            Err(_) => Html("<h1>Login Failed</h1><p>Internal server error (timeout).</p>"),
+    let session = match state.session_manager.get_session(&ip).await {
+        Some(s) => s,
+        None => return Err(Html("<h1>Login Failed</h1><p>Session not found.</p>".to_string())),
+    };
+
+    if hex::encode(session.state.redir.uamchal) != query.challenge {
+        return Err(Html("<h1>Login Failed</h1><p>Invalid challenge.</p>".to_string()));
+    }
+
+    let hashed_password = match hex::decode(form.password) {
+        Ok(p) => p,
+        Err(_) => return Err(Html("<h1>Login Failed</h1><p>Invalid password format.</p>".to_string())),
+    };
+
+    let mut chap_hasher = Md5::new();
+    chap_hasher.update(session.state.redir.uamchal);
+    if let Some(secret) = &state.config.uamsecret {
+        chap_hasher.update(secret.as_bytes());
+    }
+    let chap_challenge = chap_hasher.finalize();
+
+    let mut radius_password = Vec::with_capacity(hashed_password.len());
+    for (i, byte) in hashed_password.iter().enumerate() {
+        radius_password.push(byte ^ chap_challenge[i % 16]);
+    }
+
+    let (oneshot_tx, oneshot_rx) = oneshot::channel();
+    let auth_request = AuthRequest {
+        auth_type: AuthType::UamPap,
+        ip,
+        username: query.username,
+        password: Some(radius_password),
+        tx: oneshot_tx,
+    };
+
+    if state
+        .core_tx
+        .send(CoreRequest::Auth(auth_request))
+        .await
+        .is_err()
+    {
+        warn!("Failed to send auth request to main task");
+        return Err(Html("<h1>Login Failed</h1><p>Internal server error.</p>".to_string()));
+    }
+
+    match tokio::time::timeout(tokio::time::Duration::from_secs(10), oneshot_rx).await {
+        Ok(Ok(true)) => {
+            let user_url = session
+                .state
+                .redir
+                .userurl
+                .unwrap_or_else(|| "/status".to_string());
+            Ok(Redirect::to(&user_url))
         }
-    } else {
-        Html("<h1>Login Failed</h1><p>IPv6 is not supported.</p>")
+        Ok(Ok(false)) => Err(Html("<h1>Login Failed</h1><p>Invalid credentials.</p>".to_string())),
+        _ => Err(Html("<h1>Login Failed</h1><p>Internal server error.</p>".to_string())),
     }
 }
 
+async fn status(
+    State(state): State<AppState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+) -> Result<Html<String>, Redirect> {
+    info!("Status request from {}", addr.ip());
+
+    let ip = match addr.ip() {
+        std::net::IpAddr::V4(ip) => ip,
+        _ => return Ok(Html("<h1>Error</h1><p>IPv6 not supported.</p>".to_string())),
+    };
+
+    if let Some(session) = state.session_manager.get_session(&ip).await {
+        if session.state.authenticated {
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs();
+            let session_time = now.saturating_sub(session.state.start_time);
+            let idle_time = now.saturating_sub(session.state.last_up_time);
+
+            let body = format!(
+                r#"
+                <!doctype html>
+                <html>
+                    <head><title>Status</title></head>
+                    <body>
+                        <h1>Authenticated</h1>
+                        <p>Username: {}</p>
+                        <p>Session Time: {}s</p>
+                        <p>Idle Time: {}s</p>
+                        <p>Uploaded: {} bytes</p>
+                        <p>Downloaded: {} bytes</p>
+                        <form action="/logoff" method="get"><input type="submit" value="Log Off"></form>
+                    </body>
+                </html>
+                "#,
+                session.state.redir.username.as_deref().unwrap_or("N/A"),
+                session_time,
+                idle_time,
+                session.state.input_octets,
+                session.state.output_octets,
+            );
+            return Ok(Html(body));
+        }
+    }
+
+    Err(Redirect::to("/"))
+}
+
+async fn logoff(
+    State(state): State<AppState>,
+    ConnectInfo(addr): ConnectInfo<SocketAddr>,
+) -> Result<Redirect, Html<String>> {
+    info!("Logoff attempt from {}", addr.ip());
+
+    let ip = match addr.ip() {
+        std::net::IpAddr::V4(ip) => ip,
+        _ => return Err(Html("<h1>Error</h1><p>IPv6 not supported.</p>".to_string())),
+    };
+
+    let (oneshot_tx, oneshot_rx) = oneshot::channel();
+    let logoff_request = LogoffRequest { ip, tx: oneshot_tx };
+
+    if state
+        .core_tx
+        .send(CoreRequest::Logoff(logoff_request))
+        .await
+        .is_err()
+    {
+        warn!("Failed to send logoff request to main task");
+    } else {
+        let _ = tokio::time::timeout(tokio::time::Duration::from_secs(5), oneshot_rx).await;
+    }
+
+    Ok(Redirect::to("/"))
+}
+
 pub async fn run_server(
-    config: &Config,
-    auth_tx: mpsc::Sender<AuthRequest>,
+    config: Arc<Config>,
+    core_tx: mpsc::Sender<CoreRequest>,
+    session_manager: Arc<SessionManager>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let app_state = AppState {
+        core_tx,
+        session_manager,
+        config: config.clone(),
+    };
+
     let app = Router::new()
         .route("/", get(login_form))
         .route("/login", post(login))
-        .with_state(auth_tx);
+        .route("/logoff", get(logoff))
+        .route("/status", get(status))
+        .with_state(app_state);
 
     let addr = SocketAddr::new(config.uamlisten.into(), config.uamport);
     info!("UAM server listening on {}", addr);

--- a/coovachilli-rust/chilli-net/src/mschapv1.rs
+++ b/coovachilli-rust/chilli-net/src/mschapv1.rs
@@ -91,8 +91,12 @@ fn des_encrypt(key: &[u8; 7], data: &[u8; 8]) -> [u8; 8] {
 
 fn challenge_response(challenge: &[u8; 8], pw_hash: &[u8; 16]) -> [u8; 24] {
     let mut response = [0u8; 24];
-    let key1: &[u8; 7] = pw_hash[0..7].try_into().unwrap();
-    let key2: &[u8; 7] = pw_hash[7..14].try_into().unwrap();
+    let key1: &[u8; 7] = pw_hash[0..7]
+        .try_into()
+        .expect("pw_hash slice is guaranteed to be correct");
+    let key2: &[u8; 7] = pw_hash[7..14]
+        .try_into()
+        .expect("pw_hash slice is guaranteed to be correct");
     let mut key3 = [0u8; 7];
     key3[0..2].copy_from_slice(&pw_hash[14..16]);
 
@@ -116,8 +120,12 @@ pub fn mschap_lanman_response(challenge: &[u8; 8], secret: &str) -> [u8; 24] {
         i += 1;
     }
 
-    let key1: &[u8; 7] = padded_secret[0..7].try_into().unwrap();
-    let key2: &[u8; 7] = padded_secret[7..14].try_into().unwrap();
+    let key1: &[u8; 7] = padded_secret[0..7]
+        .try_into()
+        .expect("padded_secret slice is guaranteed to be correct");
+    let key2: &[u8; 7] = padded_secret[7..14]
+        .try_into()
+        .expect("padded_secret slice is guaranteed to be correct");
 
     let mut hash = [0u8; 16];
     hash[0..8].copy_from_slice(&des_encrypt(key1, salt));


### PR DESCRIPTION
Authentication Module) captive portal. It adds the core logic for intercepting HTTP requests from unauthenticated clients and generating an HTTP 302 redirect to the captive portal login page.

This work includes:
- A `CoreRequest` message-passing system to decouple the HTTP server from the core application logic.
- Packet-level construction of HTTP 302 redirect responses.
- An integration test (`uam_test.rs`) to simulate the full DHCP and UAM redirection flow.

Known Issues:
As requested by the user, this code is being submitted in a known incomplete state. The `uam_test.rs` test is broken and panics due to un-mocked interactions with the environment. The feature is not yet functional and will require further work to fix the test and complete the implementation. A TODO comment has been added to the test file to reflect this.