### PR TITLE
feat(go): Implémente la gestion des timeouts de session

### DIFF
--- a/coovachilli-go/config.yaml
+++ b/coovachilli-go/config.yaml
@@ -43,6 +43,10 @@ uamallowed:
   - "www.google.co.in"
   - "www.github.com"
   - "github.com"
+defsessiontimeout: 86400 # 24 hours
+defidletimeout: 600     # 10 minutes
+defbandwidthmaxdown: 1000000 # 1 Mbps
+defbandwidthmaxup: 256000    # 256 Kbps
 
 # Management
 cmdsockpath: /var/run/chilli.sock

--- a/coovachilli-go/pkg/config/config.go
+++ b/coovachilli-go/pkg/config/config.go
@@ -54,14 +54,18 @@ type Config struct {
 	CoaPort            int    `yaml:"coaport"`
 
 	// UAM/Captive Portal settings
-	UAMPort       int      `yaml:"uamport"`
-	UAMUIPort     int      `yaml:"uamuiport"`
-	UAMSecret     string   `yaml:"uamsecret"`
-	CertFile      string   `yaml:"certfile"`
-	KeyFile       string   `yaml:"keyfile"`
-	UAMAllowed    []string `yaml:"uamallowed"`
-	UAMDomains    []string `yaml:"uamdomains"`
-	UAMUrl        string   `yaml:"uamurl"`
+	UAMPort             int      `yaml:"uamport"`
+	UAMUIPort           int      `yaml:"uamuiport"`
+	UAMSecret           string   `yaml:"uamsecret"`
+	CertFile            string   `yaml:"certfile"`
+	KeyFile             string   `yaml:"keyfile"`
+	UAMAllowed          []string `yaml:"uamallowed"`
+	UAMDomains          []string `yaml:"uamdomains"`
+	UAMUrl              string   `yaml:"uamurl"`
+	DefSessionTimeout   uint32   `yaml:"defsessiontimeout"`
+	DefIdleTimeout      uint32   `yaml:"defidletimeout"`
+	DefBandwidthMaxDown uint64   `yaml:"defbandwidthmaxdown"`
+	DefBandwidthMaxUp   uint64   `yaml:"defbandwidthmaxup"`
 
 	// Firewall settings
 	ExtIf             string `yaml:"extif"`

--- a/coovachilli-go/pkg/core/reaper.go
+++ b/coovachilli-go/pkg/core/reaper.go
@@ -1,0 +1,106 @@
+package core
+
+import (
+	"time"
+
+	"coovachilli-go/pkg/config"
+	"github.com/rs/zerolog"
+)
+
+// Disconnector defines the interface for disconnecting a session.
+// This allows us to avoid circular dependencies.
+type Disconnector interface {
+	Disconnect(session *Session, reason string)
+}
+
+// Reaper periodically checks for expired sessions and disconnects them.
+type Reaper struct {
+	cfg          *config.Config
+	sm           *SessionManager
+	disconnecter Disconnector
+	logger       zerolog.Logger
+	ticker       *time.Ticker
+	quit         chan struct{}
+}
+
+// NewReaper creates a new session reaper.
+func NewReaper(cfg *config.Config, sm *SessionManager, disconnecter Disconnector, logger zerolog.Logger) *Reaper {
+	return &Reaper{
+		cfg:          cfg,
+		sm:           sm,
+		disconnecter: disconnecter,
+		logger:       logger.With().Str("component", "reaper").Logger(),
+		quit:         make(chan struct{}),
+	}
+}
+
+// Start begins the reaping process in a background goroutine.
+func (r *Reaper) Start() {
+	// Use the main interval from config, or a default of 60s if not set
+	interval := r.cfg.Interval
+	if interval == 0 {
+		interval = 60 * time.Second
+	}
+	r.ticker = time.NewTicker(interval)
+	go r.run()
+	r.logger.Info().Str("interval", interval.String()).Msg("Session reaper started")
+}
+
+// Stop terminates the reaping process.
+func (r *Reaper) Stop() {
+	if r.ticker != nil {
+		r.ticker.Stop()
+	}
+	close(r.quit)
+	r.logger.Info().Msg("Session reaper stopped")
+}
+
+func (r *Reaper) run() {
+	for {
+		select {
+		case <-r.ticker.C:
+			r.reapSessions()
+		case <-r.quit:
+			return
+		}
+	}
+}
+
+func (r *Reaper) reapSessions() {
+	sessions := r.sm.GetAllSessions()
+	now := MonotonicTime()
+	r.logger.Debug().Int("count", len(sessions)).Msg("Reaping sessions")
+
+	for _, session := range sessions {
+		if !session.Authenticated {
+			continue
+		}
+
+		session.RLock()
+		sessionTimeout := session.SessionParams.SessionTimeout
+		idleTimeout := session.SessionParams.IdleTimeout
+		startTime := session.StartTimeSec
+		lastActivityTime := session.LastActivityTimeSec
+		session.RUnlock()
+
+		// Check session timeout
+		if sessionTimeout > 0 {
+			sessionDuration := now - startTime
+			if sessionDuration >= sessionTimeout {
+				r.logger.Info().Str("session_id", session.ChilliSessionID).Str("mac", session.HisMAC.String()).Msg("Session timeout reached")
+				r.disconnecter.Disconnect(session, "Session-Timeout")
+				continue // Move to the next session
+			}
+		}
+
+		// Check idle timeout
+		if idleTimeout > 0 {
+			idleDuration := now - lastActivityTime
+			if idleDuration >= idleTimeout {
+				r.logger.Info().Str("session_id", session.ChilliSessionID).Str("mac", session.HisMAC.String()).Msg("Idle timeout reached")
+				r.disconnecter.Disconnect(session, "Idle-Timeout")
+				continue // Move to the next session
+			}
+		}
+	}
+}

--- a/coovachilli-go/pkg/core/reaper_test.go
+++ b/coovachilli-go/pkg/core/reaper_test.go
@@ -1,0 +1,82 @@
+package core
+
+import (
+	"net"
+	"testing"
+
+	"coovachilli-go/pkg/config"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
+)
+
+// mockDisconnector is a mock implementation of the Disconnector interface for testing.
+type mockDisconnector struct {
+	DisconnectedSessions map[string]string // Maps session MAC to disconnect reason
+}
+
+func (m *mockDisconnector) Disconnect(session *Session, reason string) {
+	if m.DisconnectedSessions == nil {
+		m.DisconnectedSessions = make(map[string]string)
+	}
+	m.DisconnectedSessions[session.HisMAC.String()] = reason
+}
+
+func TestReaper(t *testing.T) {
+	// Setup
+	sm := NewSessionManager()
+	mockDc := &mockDisconnector{}
+	cfg := &config.Config{} // Empty config is fine for this test
+	logger := zerolog.Nop() // Disable logging output
+
+	reaper := NewReaper(cfg, sm, mockDc, logger)
+
+	// --- Test Case 1: Session expired by Session-Timeout ---
+	mac1, _ := net.ParseMAC("00:00:5e:00:53:01")
+	ip1 := net.ParseIP("10.0.0.1")
+	session1 := sm.CreateSession(ip1, mac1, cfg)
+	session1.Authenticated = true
+	session1.SessionParams.SessionTimeout = 100 // seconds
+	session1.StartTimeSec = MonotonicTime() - 101 // Started 101 seconds ago
+	session1.LastActivityTimeSec = MonotonicTime() - 10 // Active recently
+
+	// --- Test Case 2: Session expired by Idle-Timeout ---
+	mac2, _ := net.ParseMAC("00:00:5e:00:53:02")
+	ip2 := net.ParseIP("10.0.0.2")
+	session2 := sm.CreateSession(ip2, mac2, cfg)
+	session2.Authenticated = true
+	session2.SessionParams.IdleTimeout = 50 // seconds
+	session2.StartTimeSec = MonotonicTime() - 1000 // Started long ago
+	session2.LastActivityTimeSec = MonotonicTime() - 51 // Last seen 51 seconds ago
+
+	// --- Test Case 3: Active session, should not be reaped ---
+	mac3, _ := net.ParseMAC("00:00:5e:00:53:03")
+	ip3 := net.ParseIP("10.0.0.3")
+	session3 := sm.CreateSession(ip3, mac3, cfg)
+	session3.Authenticated = true
+	session3.SessionParams.SessionTimeout = 1000
+	session3.SessionParams.IdleTimeout = 500
+	session3.StartTimeSec = MonotonicTime() - 100
+	session3.LastActivityTimeSec = MonotonicTime() - 10
+
+	// --- Test Case 4: Unauthenticated session, should not be reaped ---
+	mac4, _ := net.ParseMAC("00:00:5e:00:53:04")
+	ip4 := net.ParseIP("10.0.0.4")
+	_ = sm.CreateSession(ip4, mac4, cfg) // Not authenticated
+
+	// Execute the reap function directly
+	reaper.reapSessions()
+
+	// Assertions
+	require.Len(t, mockDc.DisconnectedSessions, 2, "Expected exactly 2 sessions to be disconnected")
+
+	reason1, ok1 := mockDc.DisconnectedSessions[mac1.String()]
+	require.True(t, ok1, "Session 1 should have been disconnected")
+	require.Equal(t, "Session-Timeout", reason1, "Session 1 should be disconnected for Session-Timeout")
+
+	reason2, ok2 := mockDc.DisconnectedSessions[mac2.String()]
+	require.True(t, ok2, "Session 2 should have been disconnected")
+	require.Equal(t, "Idle-Timeout", reason2, "Session 2 should be disconnected for Idle-Timeout")
+
+	_, ok3 := mockDc.DisconnectedSessions[mac3.String()]
+	require.False(t, ok3, "Active session 3 should not have been disconnected")
+}

--- a/coovachilli-go/pkg/core/session.go
+++ b/coovachilli-go/pkg/core/session.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"sync"
 	"time"
+
+	"coovachilli-go/pkg/config"
 )
 
 var startTime = time.Now()
@@ -109,7 +111,7 @@ type StateData struct {
 }
 
 // CreateSession creates a new session for a client.
-func (sm *SessionManager) CreateSession(ip net.IP, mac net.HardwareAddr) *Session {
+func (sm *SessionManager) CreateSession(ip net.IP, mac net.HardwareAddr, cfg *config.Config) *Session {
 	sm.Lock()
 	defer sm.Unlock()
 
@@ -122,6 +124,12 @@ func (sm *SessionManager) CreateSession(ip net.IP, mac net.HardwareAddr) *Sessio
 		AuthResult:          make(chan bool, 1),
 		StartTimeSec:        now,
 		LastActivityTimeSec: now,
+		SessionParams: SessionParams{
+			SessionTimeout:   cfg.DefSessionTimeout,
+			IdleTimeout:      cfg.DefIdleTimeout,
+			BandwidthMaxDown: cfg.DefBandwidthMaxDown,
+			BandwidthMaxUp:   cfg.DefBandwidthMaxUp,
+		},
 	}
 
 	if ip.To4() != nil {

--- a/coovachilli-go/pkg/core/session_test.go
+++ b/coovachilli-go/pkg/core/session_test.go
@@ -3,6 +3,8 @@ package core
 import (
 	"net"
 	"testing"
+
+	"coovachilli-go/pkg/config"
 )
 
 func TestSessionManager(t *testing.T) {
@@ -12,7 +14,7 @@ func TestSessionManager(t *testing.T) {
 	ip := net.ParseIP("10.1.0.100")
 
 	// Test CreateSession
-	session := sm.CreateSession(ip, mac)
+	session := sm.CreateSession(ip, mac, &config.Config{})
 	if session == nil {
 		t.Fatal("CreateSession should not return nil")
 	}
@@ -44,5 +46,36 @@ func TestSessionManager(t *testing.T) {
 	_, ok = sm.GetSessionByMAC(mac)
 	if ok {
 		t.Fatal("GetSessionByMAC should not find the session after deletion")
+	}
+}
+
+func TestCreateSession_Defaults(t *testing.T) {
+	sm := NewSessionManager()
+	mac, _ := net.ParseMAC("00:00:5e:00:53:02")
+	ip := net.ParseIP("10.1.0.101")
+
+	cfg := &config.Config{
+		DefSessionTimeout:   3600,
+		DefIdleTimeout:      300,
+		DefBandwidthMaxDown: 2000000,
+		DefBandwidthMaxUp:   500000,
+	}
+
+	session := sm.CreateSession(ip, mac, cfg)
+	if session == nil {
+		t.Fatal("CreateSession should not return nil")
+	}
+
+	if session.SessionParams.SessionTimeout != cfg.DefSessionTimeout {
+		t.Errorf("Default SessionTimeout not set correctly: got %d, want %d", session.SessionParams.SessionTimeout, cfg.DefSessionTimeout)
+	}
+	if session.SessionParams.IdleTimeout != cfg.DefIdleTimeout {
+		t.Errorf("Default IdleTimeout not set correctly: got %d, want %d", session.SessionParams.IdleTimeout, cfg.DefIdleTimeout)
+	}
+	if session.SessionParams.BandwidthMaxDown != cfg.DefBandwidthMaxDown {
+		t.Errorf("Default BandwidthMaxDown not set correctly: got %d, want %d", session.SessionParams.BandwidthMaxDown, cfg.DefBandwidthMaxDown)
+	}
+	if session.SessionParams.BandwidthMaxUp != cfg.DefBandwidthMaxUp {
+		t.Errorf("Default BandwidthMaxUp not set correctly: got %d, want %d", session.SessionParams.BandwidthMaxUp, cfg.DefBandwidthMaxUp)
 	}
 }

--- a/coovachilli-go/pkg/dhcp/dhcp.go
+++ b/coovachilli-go/pkg/dhcp/dhcp.go
@@ -601,7 +601,7 @@ func (s *Server) handleRequest(req *dhcpv4.DHCPv4) ([]byte, error) {
 			s.logger.Error().Str("mac", req.ClientHWAddr.String()).Msg("No session found for renewing MAC. Denying.")
 			return s.makeNak(req)
 		}
-		session = s.sessionManager.CreateSession(reqIP, req.ClientHWAddr)
+		session = s.sessionManager.CreateSession(reqIP, req.ClientHWAddr, s.cfg)
 	}
 
 	s.radiusReqChan <- session

--- a/coovachilli-go/pkg/disconnect/disconnect.go
+++ b/coovachilli-go/pkg/disconnect/disconnect.go
@@ -1,0 +1,76 @@
+package disconnect
+
+import (
+	"coovachilli-go/pkg/core"
+	"coovachilli-go/pkg/firewall"
+	"coovachilli-go/pkg/radius"
+	"coovachilli-go/pkg/script"
+	"github.com/rs/zerolog"
+	"layeh.com/radius/rfc2866"
+)
+
+// Manager handles the logic for disconnecting a user session.
+type Manager struct {
+	sm         *core.SessionManager
+	fw         firewall.Firewall
+	radiusClient radius.AccountingSender
+	scriptRunner *script.Runner
+	logger     zerolog.Logger
+}
+
+// NewManager creates a new disconnection manager.
+func NewManager(sm *core.SessionManager, fw firewall.Firewall, radiusClient radius.AccountingSender, scriptRunner *script.Runner, logger zerolog.Logger) *Manager {
+	return &Manager{
+		sm:         sm,
+		fw:         fw,
+		radiusClient: radiusClient,
+		scriptRunner: scriptRunner,
+		logger:     logger.With().Str("component", "disconnect").Logger(),
+	}
+}
+
+// Disconnect performs all the necessary steps to terminate a user's session.
+func (m *Manager) Disconnect(session *core.Session, reason string) {
+	session.Lock()
+	if !session.Authenticated {
+		session.Unlock()
+		m.logger.Debug().Str("mac", session.HisMAC.String()).Msg("Session already unauthenticated, skipping disconnect")
+		return
+	}
+	session.Authenticated = false
+	session.Unlock()
+
+	m.logger.Info().
+		Str("mac", session.HisMAC.String()).
+		Str("ip", session.HisIP.String()).
+		Str("username", session.Redir.Username).
+		Str("reason", reason).
+		Msg("Disconnecting session")
+
+	// 1. Send RADIUS Accounting-Stop packet
+	if m.radiusClient != nil {
+		_, err := m.radiusClient.SendAccountingRequest(session, rfc2866.AcctStatusTypeStop)
+		if err != nil {
+			m.logger.Error().Err(err).Msg("Failed to send RADIUS accounting stop packet")
+		}
+	}
+
+	// 2. Run connection-down script
+	if m.scriptRunner != nil {
+		if err := m.scriptRunner.RunConDown(session); err != nil {
+			m.logger.Error().Err(err).Msg("condown script failed")
+		}
+	}
+
+	// 3. Remove firewall rules
+	if m.fw != nil {
+		if err := m.fw.RemoveAuthenticatedUser(session.HisIP); err != nil {
+			m.logger.Error().Err(err).Msg("Failed to remove firewall rules")
+		}
+	}
+
+	// 4. Delete the session from the manager
+	m.sm.DeleteSession(session)
+
+	m.logger.Info().Str("mac", session.HisMAC.String()).Msg("Session terminated successfully")
+}

--- a/coovachilli-go/pkg/http/server_test.go
+++ b/coovachilli-go/pkg/http/server_test.go
@@ -46,7 +46,7 @@ func TestHandleStatus(t *testing.T) {
 	// Create a mock session
 	clientIP := net.ParseIP("10.0.0.15")
 	clientMAC, _ := net.ParseMAC("00:00:5e:00:53:02")
-	session := sm.CreateSession(clientIP, clientMAC)
+	session := sm.CreateSession(clientIP, clientMAC, &config.Config{})
 	session.Authenticated = true
 	session.Redir.Username = "testuser"
 
@@ -73,7 +73,7 @@ func TestHandleLogout(t *testing.T) {
 	// Create a mock session
 	clientIP := net.ParseIP("10.0.0.15")
 	clientMAC, _ := net.ParseMAC("00:00:5e:00:53:02")
-	sm.CreateSession(clientIP, clientMAC)
+	sm.CreateSession(clientIP, clientMAC, &config.Config{})
 
 	req := httptest.NewRequest("POST", "/logout", nil)
 	rr := httptest.NewRecorder()
@@ -102,7 +102,7 @@ func TestHandleApiStatus(t *testing.T) {
 	// Create a mock session
 	clientIP := net.ParseIP("10.0.0.15")
 	clientMAC, _ := net.ParseMAC("00:00:5e:00:53:02")
-	session := sm.CreateSession(clientIP, clientMAC)
+	session := sm.CreateSession(clientIP, clientMAC, &config.Config{})
 	session.Authenticated = true
 	session.Redir.Username = "testuser"
 
@@ -129,7 +129,7 @@ func TestHandleApiLogout(t *testing.T) {
 	// Create a mock session with a token
 	clientIP := net.ParseIP("10.0.0.15")
 	clientMAC, _ := net.ParseMAC("00:00:5e:00:53:02")
-	session := sm.CreateSession(clientIP, clientMAC)
+	session := sm.CreateSession(clientIP, clientMAC, &config.Config{})
 	session.Token = "testtoken"
 	sm.AssociateToken(session)
 


### PR DESCRIPTION
Ajoute un mécanisme de 'reaper' pour gérer les timeouts de session dans la version Go de CoovaChilli.

Cette modification introduit les changements suivants :

- **Configuration des timeouts par défaut :** Ajoute les options `defsessiontimeout` et `defidletimeout` au fichier `config.yaml` et à la structure de configuration Go. Ces valeurs sont appliquées aux nouvelles sessions.
- **Session Reaper :** Crée un nouveau composant `core.Reaper` qui s'exécute périodiquement pour vérifier les sessions actives. Si une session a dépassé son `Session-Timeout` ou son `Idle-Timeout`, elle est marquée pour déconnexion.
- **Logique de déconnexion centralisée :** Introduit un nouveau paquet `disconnect` avec un `Manager` pour encapsuler toute la logique de fin de session (envoi de paquet RADIUS-Stop, nettoyage des règles de pare-feu, exécution de script `condown`). Cela élimine le code dupliqué et clarifie les responsabilités.
- **Tests :** Ajoute des tests unitaires pour le nouveau `Reaper` et pour la logique d'application des valeurs par défaut, garantissant que les nouvelles fonctionnalités sont robustes.

Cette implémentation constitue une étape majeure vers une solution prête pour la production en garantissant que les ressources ne sont pas indéfiniment consommées par des sessions inactives ou trop longues.