### PR TITLE
Fix: Resolve gopacket dependency conflict and test failures

### DIFF
--- a/coovachilli-go/pkg/icmpv6/radvert.go
+++ b/coovachilli-go/pkg/icmpv6/radvert.go
@@ -46,7 +46,7 @@ func BuildRouterAdvertisement(cfg *config.Config, soliciterIP net.IP) ([]byte, e
 	}
 
 	optSrcLLAddr := layers.ICMPv6Option{
-		Type: layers.ICMPv6OptionSourceLinkLayerAddress,
+		Type: layers.ICMPv6OptSourceAddress,
 		Data: routerMAC,
 	}
 
@@ -59,7 +59,7 @@ func BuildRouterAdvertisement(cfg *config.Config, soliciterIP net.IP) ([]byte, e
 	copy(optPrefixInfoData[16:], cfg.NetV6.IP.To16())
 
 	optPrefixInfo := layers.ICMPv6Option{
-		Type: layers.ICMPv6OptionPrefixInfo,
+		Type: layers.ICMPv6OptPrefixInfo,
 		Data: optPrefixInfoData,
 	}
 


### PR DESCRIPTION
This commit resolves a major dependency conflict and a cascade of resulting build and test failures.

The key changes include:
- Migrated the project from the deprecated `github.com/google/gopacket` to the modern, community-maintained `github.com/gopacket/gopacket`.
- Updated all Go files that used the old import path.
- Corrected compilation errors in `pkg/icmpv6/radvert.go` by using the correct constant names from the new `gopacket` library.
- Fixed a Go syntax error in `cmd/coovachilli/main.go` where a function was incorrectly nested.
- Completely refactored the DHCP tests in `pkg/dhcp/dhcp_test.go` to use the modern API of the `insomniacslk/dhcp` library.
- Debugged and fixed a persistent failure in `TestRelayDHCPv4` by:
    - Correcting the construction of DHCP Option 82 (Relay Agent Information).
    - Ensuring the relay function correctly parses the upstream server's host and port.
    - Fixing the test packet's serialization to include a valid UDP checksum.

The entire Go test suite now passes, and the application builds successfully.